### PR TITLE
tooling: shift headings (use h1 as top-level headings)

### DIFF
--- a/admin/exams.md
+++ b/admin/exams.md
@@ -2,7 +2,7 @@
 title: "Prüfungsvorbereitung"
 author: "Carsten Gips (HSBI)"
 tldr: |
-    ### Durchführung: Präsenz oder Open-Book (je nach Corona-Lage)
+    **Durchführung: Präsenz oder Open-Book (je nach Corona-Lage)**
 
     Die Klausur wird dieses Semester elektronisch stattfinden. Dazu werden wir den Prüfungs-ILIAS der
     HSBI nutzen.
@@ -22,13 +22,13 @@ tldr: |
     Die Entscheidung über die konkrete Durchführung wird spätestens zwei Wochen vor der Prüfung getroffen
     und Ihnen per EMail über das LSF mitgeteilt.
 
-    ### Ablauf der Klausur
+    **Ablauf der Klausur**
 
     Die Prüfung (das ILIAS-Objekt) selbst schalte ich erst zum Start der Prüfung online. Bei der Durchführung
     als Open-Book-Ausarbeitung wird parallel zur Prüfung eine Zoom-Sitzung laufen, in der Sie Fragen stellen
     können.
 
-    ### Hilfsmittel und Themen
+    **Hilfsmittel und Themen**
 
     Bei der Durchführung in Präsenz am Campus Minden ist ein Spickzettel (DIN A4, beidseitig beschrieben)
     als Hilfsmittel zugelassen.
@@ -56,9 +56,9 @@ attachments:
 ---
 
 
-## Elektronische Klausur: Termin, Materialien
+# Elektronische Klausur: Termin, Materialien
 
-### Termin
+## Termin
 
 Die schriftliche Prüfung erfolgt durch eine Klausur, die als digitale Prüfung auf einem
 Prüfungs-ILIAS durchgeführt wird.
@@ -75,7 +75,7 @@ Dauer jeweils 90 Minuten.
 *   Die konkrete Durchführungsform [(in Präsenz am Campus Minden oder im Home-Office)]{.notes}
     wird Ihnen [spätestens]{.notes} zwei Wochen vor der Prüfung über das LSF bekanntgegeben
 
-### Zugelassene Hilfsmittel
+## Zugelassene Hilfsmittel
 
 ::: {.details title="Präsenz (in Minden)"}
 
@@ -102,12 +102,12 @@ Sie alle Unterlagen benutzen.
 
 :::
 
-### Einsicht
+## Einsicht
 
 *   Prüfungseinsicht: Zeitnah; Bekanntgabe per Mail
 
 
-## Technische Vorbereitungen
+# Technische Vorbereitungen
 
 ::: {.details title="Präsenz (in Minden)"}
 
@@ -175,7 +175,7 @@ für Sie vorbereitet sein.
 :::
 
 
-## Bearbeitung des E-Assessment
+# Bearbeitung des E-Assessment
 
 1.  Lesen Sie sich die Hinweise auf der Startseite durch
 
@@ -207,7 +207,7 @@ für Sie vorbereitet sein.
         Täuschungsversuch gewertet werden, vgl. RPO §22a (4))]{.notes}
 
 
-## Fragetypen-Demo
+# Fragetypen-Demo
 
 In Ihrem ILIAS-Kurs finden Sie eine
 [**Fragetypen-Demo**](https://www.hsbi.de/elearning/goto.php?target=tst_1352273&client_id=FH-Bielefeld)
@@ -216,7 +216,7 @@ Sie sich die Kommentare bei den einzelnen Aufgaben an. Sie können die Demo bei 
 wiederholen.
 
 
-## Hinweise zu den Inhalten
+# Hinweise zu den Inhalten
 
 *   Klausurrelevant: Vorlesung und Praktikum
 *   Für Verständnis u.U. hilfreich: Studium der vertiefenden Literaturangaben
@@ -234,9 +234,9 @@ wiederholen.
 :::
 
 
-## Beispiele für mögliche Fragen
+# Beispiele für mögliche Fragen
 
-### Vererbung und Polymorphie
+## Vererbung und Polymorphie
 
 Betrachten Sie den folgenden Java-Code:
 
@@ -261,7 +261,7 @@ Geben Sie alle Ausgaben, die das obige Programm produziert, an.
 Begründen Sie Ihre Antwort kurz und stichhaltig (für *jede* Ausgabe!).
 Was geschieht, bzw. wieso kommt es zu der jeweiligen Ausgabe?
 
-### Multithreading und Synchronisierung
+## Multithreading und Synchronisierung
 
 ```java
 public class StaffelKaputt extends Thread {
@@ -289,12 +289,12 @@ Welche Ausgabe erwarten Sie (angenommen, das Programm wäre fehlerfrei; eine
 mögliche Variante reicht)? Welche Ausgabe erhalten Sie stattdessen? Korrigieren
 Sie den Fehler.
 
-### Reguläre Ausdrücke
+## Reguläre Ausdrücke
 
 Auf welche Strings passt (im Sinne von "match") der folgende reguläre
 Ausdruck: `\s*([a-zA-Z0-9_.\-]+)\s*=\s*(-?\d+\.?\d*)\s;?\s*`
 
-### Versionieren mit Git
+## Versionieren mit Git
 
 *   Erklären Sie, wie man mit Git die Unterschiede zwischen zwei
     bestimmten Versionsständen einer Datei herausfindet.
@@ -316,7 +316,7 @@ Ausdruck: `\s*([a-zA-Z0-9_.\-]+)\s*=\s*(-?\d+\.?\d*)\s;?\s*`
 
 *   Was würde `git diff` jeweils nach Schritt 2 anzeigen?
 
-### Kommandozeilenparameter
+## Kommandozeilenparameter
 
 Schreiben Sie ein Programm, welches auf zwei Kommandozeilenparameter reagieren
 kann. Die erkannten Parameter sollen auf der Konsole ausgegeben werden. Nutzen
@@ -330,7 +330,7 @@ Sie Apache Commons CLI (API siehe Anhang).
 *   Die Parameter können in unterschiedlicher Reihenfolge auftreten.
 *   Es kann auch nur ein Parameter angegeben werden.
 
-### Build mit Ant
+## Build mit Ant
 
 *   Was ist der Unterschied zwischen Ant-Targets und Ant-Tasks?
 *   Wie kann man Ant-Properties von außen (beim Aufruf) setzen?
@@ -342,7 +342,7 @@ Sie Apache Commons CLI (API siehe Anhang).
 *   Schreiben Sie Ant-Targets, mit denen Sie JUnit-Testfälle ausführen und
     auswerten können.
 
-### Generics
+## Generics
 
 Was kommt hier raus? Und warum?
 
@@ -363,7 +363,7 @@ public class X {
 }
 ```
 
-### Logging
+## Logging
 
 Erklären Sie den Code. Was passiert?
 
@@ -391,7 +391,7 @@ public class MoreLogging {
 }
 ```
 
-### Methodenreferenzen
+## Methodenreferenzen
 
 *   Was bedeutet der folgende Code?
 

--- a/homework/b01.md
+++ b/homework/b01.md
@@ -13,7 +13,7 @@ der LV "Programmieren 1".*
 
 Implementieren Sie in Java das Spiel [Hangman].
 
-## A01.1: Installation JDK und IDE, Deaktivierung AI-Support
+# A01.1: Installation JDK und IDE, Deaktivierung AI-Support
 
 Sie benötigen für die Bearbeitung der Übungsaufgaben ein *Java Development Kit* (JDK). Wir
 verwenden in der Lehrveranstaltung "Programmieren 2" aus verschiedenen Gründen die *Long-Term
@@ -34,7 +34,7 @@ sämtliche KI-Unterstützung wie beispielsweise Copilot, JetBrains AI Assistant,
 CodeGPT, Codeium, Tabnine, Windsurf, ... (Liste nicht vollständig) für die Bearbeitung der
 Übungsaufgaben in dieser Lehrveranstaltung ab.
 
-## A01.2: Anlegen eines Java-Projektes
+# A01.2: Anlegen eines Java-Projektes
 
 Legen Sie für die Bearbeitung der Aufgabe ein neues Java-Projekt in Ihrer IDE an. Achten Sie
 bitte darauf, dass im Projektpfad **keine Leerzeichen** und **keine Sonderzeichen** (Umlaute
@@ -56,7 +56,7 @@ Testen Sie bitte die genutzte Java-Version:
 
 Korrigieren Sie Ihr Setup, wenn Sie andere Ausgaben erhalten.
 
-## A01.3: Übersetzen und Starten und Debuggen von Programmen
+# A01.3: Übersetzen und Starten und Debuggen von Programmen
 
 Erstellen Sie in Ihrem neuen Projekt die folgende Klasse:
 
@@ -81,7 +81,7 @@ Starten Sie das obige Programm im Debug-Modus Ihrer IDE. Halten Sie die Ausführ
 die nächste Anweisung (das `System.out.println`) aus. Wie beenden Sie das Programm?
 Demonstrieren Sie das live im Praktikum.
 
-## A01.4: Swing und Java2D
+# A01.4: Swing und Java2D
 
 Das Spiel soll vollständig über eine in Swing und Java2D realisierte GUI bedient werden:
 
@@ -91,7 +91,7 @@ Das Spiel soll vollständig über eine in Swing und Java2D realisierte GUI bedie
 4.  Die bisher eingegebenen Buchstaben sollen in der Reihenfolge der Eingabe angezeigt werden.
 5.  Das Spiel soll per Knopfdruck abgebrochen und neu gestartet werden können.
 
-## A01.5: Einlesen von Textdateien
+# A01.5: Einlesen von Textdateien
 
 Es soll die Möglichkeit geben, eine Textdatei mit zu ratenden Wörtern einzulesen:
 
@@ -105,11 +105,11 @@ Es soll die Möglichkeit geben, eine Textdatei mit zu ratenden Wörtern einzules
 6.  Es soll für jedes neue Spiel ein zufälliges Wort aus der Menge der eingelesenen Wörter zum
     Raten ausgewählt werden.
 
-## A01.6: Dokumentation
+# A01.6: Dokumentation
 
 Erstellen Sie ein UML-Klassendiagramm für Ihre Lösung.
 
-## A01.7: Fortgeschrittenere Aufgaben
+# A01.7: Fortgeschrittenere Aufgaben
 
 1.  Heben Sie in der Anzeige der eingegebenen Buchstaben die korrekt geratenen Buchstaben in
     grüner Farbe hervor.

--- a/homework/b02.md
+++ b/homework/b02.md
@@ -8,9 +8,9 @@ attachments:
 
 <!--  pandoc -s -f markdown -t markdown+smart-grid_tables-multiline_tables-simple_tables --columns=94 --reference-links=true  b02.md  -o xxx.md  -->
 
-## Git
+# Git
 
-### A02.1: Git Status erklären
+## A02.1: Git Status erklären
 
 Betrachten Sie die folgende Ausgabe von `git status` in einer lokalen Workingcopy
 (*Arbeitskopie*):
@@ -35,7 +35,7 @@ Erklären Sie die Ausgabe.
 Geben Sie eine Befehlssequenz an, mit der Sie nur die Änderungen in `foo.java` committen
 können.
 
-### A02.2: Git-Spiel
+## A02.2: Git-Spiel
 
 Klonen Sie die [Vorgaben "Git-Quest"]. Sie finden die Geschichte des Helden Markus im
 Dungeon.[^1]
@@ -71,7 +71,7 @@ Dungeon.[^1]
 
 Demonstrieren Sie Ihr Vorgehen im Praktikum jeweils live.
 
-### A02.3: Commit-Meldungen
+## A02.3: Commit-Meldungen
 
 Gute Commit-Meldungen schreiben erfordert Übung. Schauen Sie sich die beiden Commits
 [Dungeon-CampusMinden/Dungeon/commit/46530b6] und
@@ -80,7 +80,7 @@ Gute Commit-Meldungen schreiben erfordert Übung. Schauen Sie sich die beiden Co
 Diskutieren Sie jeweils, was Ihnen an den Commits auffällt: Was gefällt Ihnen, was stört Sie?
 Schlagen Sie Verbesserungen vor.
 
-## A02.4: Gradle
+# A02.4: Gradle
 
 Folgen Sie der Anleitung auf [gradle.org] und installieren Sie Gradle auf Ihrem Rechner. Legen
 Sie in der Konsole ein neues Gradle-Projekt für eine Java-Applikation an (ohne IDE!). Das
@@ -98,7 +98,7 @@ Aufgaben diese Abschnitte jeweils erfüllen. Gehen Sie dabei im *Detail* auf das
 Machen Sie sich Notizen, welche Sie im Praktikum nutzen dürfen, um dort das Buildskript zu
 erklären.
 
-## A02.5: Calculator: Anonyme Klassen und Lambda-Ausdrücke
+# A02.5: Calculator: Anonyme Klassen und Lambda-Ausdrücke
 
 Klonen Sie die [Vorgaben "Calculator"] und laden Sie das Projekt als Gradle-Projekt in Ihre
 IDE.

--- a/homework/b03.md
+++ b/homework/b03.md
@@ -8,7 +8,7 @@ attachments:
 
 <!--  pandoc -s -f markdown -t markdown+smart-grid_tables-multiline_tables-simple_tables --columns=94 --reference-links=true  b03.md  -o xxx.md  -->
 
-## A03.1: Git-Spiel
+# A03.1: Git-Spiel
 
 Betrachten Sie erneut die [Vorgaben zur "Git-Quest"]. Die Geschichte des Helden Markus findet
 im `master`-Branch kein Ende, sondern erst im Hilfsbranch `end`.
@@ -34,12 +34,12 @@ einem frischen Klon der Vorgaben.
 Was beobachten Sie jeweils? Erklären Sie Ihre Beobachtungen. Wenn es Konflikte gibt: Wie lösen
 Sie diese auf? Demonstrieren Sie das Vorgehen im Praktikum live.
 
-## LSF-Contact
+# LSF-Contact
 
 Betrachten Sie die [Vorgaben "LSF-Contact"]. Klonen Sie das Repo und laden Sie das Projekt als
 Gradle-Projekt in Ihre IDE.
 
-### A03.2: Methoden-Referenzen
+## A03.2: Methoden-Referenzen
 
 Sie finden im Package `lsfcontact` eine Klasse `Student`. Jede Instanz dieser Klasse hat
 mindestens einen Namen (`String`), und man kann verschiedene Konktaktmöglichkeiten per Setter
@@ -77,7 +77,7 @@ Schaffen Sie es, diese durch Methodenreferenzen zu ersetzen?
 Achten Sie darauf, alle Schritte nachvollziehbar in Ihrer Arbeitskopie per Git Commit
 festzuhalten. Demonstrieren Sie dies im Praktikum.
 
-### A03.3: Logging
+## A03.3: Logging
 
 Bauen Sie für das `LsfContactUtil` ein Logging auf der Basis von `java.util.logging` ein: Jede
 Benachrichtigung von Studierenden soll in ein gemeinsames CSV-File geloggt werden. Dabei soll

--- a/homework/b04.md
+++ b/homework/b04.md
@@ -14,9 +14,9 @@ Aufgaben in einem öffentlich sichtbaren Git-Repo durchführen sollen. Den Link 
 jeweiligen Lösungs-Repo geben Sie bitte in Ihrem *Post Mortem* mit an.
 :::
 
-## Stream-API
+# Stream-API
 
-### A04.1: Git: Pull-Requests (und Code-Formatierung und -Dokumentation)
+## A04.1: Git: Pull-Requests (und Code-Formatierung und -Dokumentation)
 
 Forken Sie das ["Stream-API"]-Repo und erzeugen Sie eine lokale Arbeitskopie von Ihrem Fork.
 
@@ -30,7 +30,7 @@ einen Pull-Request auf **Ihren** eigenen `master`-Branch.
 Achten Sie darauf, alle Schritte nachvollziehbar in Ihrer Arbeitskopie per Git-Commit
 festzuhalten. Demonstrieren Sie im Praktikum, wie Sie mit den Pull-Requests arbeiten.
 
-### A04.2: Stream-API: Task I
+## A04.2: Stream-API: Task I
 
 Betrachten Sie den Branch `task_i`. Sie finden im Package `streamapi` einige Hilfsklassen
 sowie in der Datei [`Main.java`] einen Starter für diese erste Teilaufgabe.
@@ -42,7 +42,7 @@ Schreiben Sie den Body dieser Methode so um, dass die selbe Funktionalität unte
 [Java-Stream-API] erreicht wird. Bevorzugen Sie dabei nach Möglichkeit Methoden-Referenzen vor
 Lambda-Ausdrücken.
 
-### A04.3: Stream-API: Task II
+## A04.3: Stream-API: Task II
 
 Betrachten Sie nun den Branch `task_ii`. Sie finden wieder im Package `streamapi` einige
 Hilfsklassen sowie in der Datei [`Main.java`][1] einen Starter für diese zweite Teilaufgabe.
@@ -57,7 +57,7 @@ Schreiben Sie den Body dieser Methode so um, dass die selbe Funktionalität unte
 [Java-Stream-API] erreicht wird. Bevorzugen Sie dabei nach Möglichkeit Methoden-Referenzen vor
 Lambda-Ausdrücken.
 
-### A04.4: Stream-API: Task III
+## A04.4: Stream-API: Task III
 
 Betrachten Sie nun den Branch `task_iii`. Sie finden wieder im Package `streamapi` einige
 Hilfsklassen sowie in der Datei [`Main.java`][2] einen Starter für diese dritte Teilaufgabe.
@@ -70,7 +70,7 @@ Schreiben Sie den Body dieser Methode so um, dass die selbe Funktionalität unte
 [Java-Stream-API] erreicht wird. Bevorzugen Sie dabei nach Möglichkeit Methoden-Referenzen vor
 Lambda-Ausdrücken.
 
-### A04.5: Stream-API: Task IV+V
+## A04.5: Stream-API: Task IV+V
 
 Betrachten Sie nun den Branch `task_iv_v`. Sie finden wieder im Package `streamapi` einige
 Hilfsklassen sowie in der Datei [`Main.java`][3] einen Starter für diese vierte Teilaufgabe.
@@ -105,11 +105,11 @@ Hilfsklassen sowie in der Datei [`Main.java`][3] einen Starter für diese vierte
     der [Java-Stream-API] erreicht wird. Bevorzugen Sie dabei nach Möglichkeit
     Methoden-Referenzen vor Lambda-Ausdrücken.
 
-### A04.6: Record-Klassen
+## A04.6: Record-Klassen
 
 Machen Sie aus der Klasse `streamapi.Student` eine Record-Klasse.
 
-## A04.7: DevDungeon: Zerbrechende Tiles und Speed Potions (Lambda-Ausdrücke)
+# A04.7: DevDungeon: Zerbrechende Tiles und Speed Potions (Lambda-Ausdrücke)
 
 Klonen Sie das Projekt [DevDungeon] und laden Sie es in Ihrer IDE als Gradle-Projekt.
 Betrachten Sie das Sub-Projekt[^1] "devDungeon". Dies ist ein von einem Studierenden

--- a/homework/b05.md
+++ b/homework/b05.md
@@ -8,7 +8,7 @@ attachments:
 
 <!--  pandoc -s -f markdown -t markdown+smart-grid_tables-multiline_tables-simple_tables --columns=94 --reference-links=true  b05.md  -o xxx.md  -->
 
-## A05.1: DevDungeon: Fackeln im Sturm (Streams, Optional)
+# A05.1: DevDungeon: Fackeln im Sturm (Streams, Optional)
 
 Klonen Sie das Projekt [DevDungeon] und laden Sie es in Ihrer IDE als Gradle-Projekt.
 Betrachten Sie das Sub-Projekt "devDungeon". Dies ist ein von einem Studierenden ([\@Flamtky])
@@ -41,7 +41,7 @@ Task `devDungeon:runDevDungeon` aus der IDE heraus) starten.
 Sonderzeichen (Umlaute o.ä.) vorkommen! Dies kann zu seltsamen Fehler führen. Bitte auch
 darauf achten, dass Sie als JDK ein **Java SE 21 (LTS)** verwenden.
 
-## Katzen-Café
+# Katzen-Café
 
 Forken Sie das ["Cat-Cafe"]-Repo und erzeugen Sie sich eine lokale Arbeitskopie von Ihrem
 Fork.
@@ -55,7 +55,7 @@ eigenen `master`-Branch.
 Achten Sie darauf, alle Schritte nachvollziehbar in Ihrer Arbeitskopie per Git-Commit
 festzuhalten. Demonstrieren Sie im Praktikum, wie Sie mit den Pull-Requests arbeiten.
 
-### A05.2: Code-Analyse
+## A05.2: Code-Analyse
 
 Analysieren Sie die Modellierung des Binärbaums (`Tree`, `Empty`, `Node`) und erklären Sie die
 Funktionsweise:
@@ -66,7 +66,7 @@ Funktionsweise:
   `Tree<X> mytree; mytree.stream(). ...` nutzen zu können?
 - Wie funktioniert der `TreeIterator`?
 
-### A05.3: Optional
+## A05.3: Optional
 
 Bauen Sie die beiden Methoden `CatCafe#getCatByName` und `CatCafe#getCatByWeight` so um, dass
 ein passendes `Optional` zurückgeliefert wird. Passen Sie die entsprechenden Methodenaufrufe
@@ -75,7 +75,7 @@ in `Main#main` entsprechend an.
 *Tipp*: Stellen Sie in den beiden Methoden auf die [Java-Stream-API] um, dann ergibt sich die
 Nutzung von `Optional` fast von selbst.
 
-### A05.4: JUnit
+## A05.4: JUnit
 
 Erstellen Sie mit JUnit 4 oder 5 mindestens 10 unterschiedliche Testfälle für die Klasse
 `CatCafe`.
@@ -87,7 +87,7 @@ automatisch zur Verfügung. Wenn Sie JUnit4 nutzen möchten, müssten Sie bitte 
 Gradle-Konfiguration entsprechend anpassen. Mit `./gradlew test` können Sie entsprechende
 Testfälle ausführen.
 
-### A05.5: Visitor-Pattern
+## A05.5: Visitor-Pattern
 
 Die Klasse `CatCafe` hat eine Methode `CatCafe#accept`, die einen Visitor mit dem
 parametrischen Typ `TreeVisitor` an das intern genutzte Feld `Tree<FelineOverLord> clowder`

--- a/homework/b06.md
+++ b/homework/b06.md
@@ -8,8 +8,6 @@ attachments:
 
 <!--  pandoc -s -f markdown -t markdown+smart-grid_tables-multiline_tables-simple_tables --columns=94 --reference-links=true  b06.md  -o xxx.md  -->
 
-## Cycle Chronicles
-
 Forken Sie das ["Cycle Chronicles"]-Repo und erzeugen Sie sich eine lokale Arbeitskopie von
 Ihrem Fork.
 
@@ -22,7 +20,7 @@ eigenen `master`-Branch.
 Achten Sie darauf, alle Schritte nachvollziehbar in Ihrer Arbeitskopie per Git-Commit
 festzuhalten. Demonstrieren Sie im Praktikum, wie Sie mit den Pull-Requests arbeiten.
 
-### A06.1: Analyse: Äquivalenzklassen & Grenzwerte
+# A06.1: Analyse: Äquivalenzklassen & Grenzwerte
 
 Die Methode `Shop#accept` dient zur Annahme eines neuen Auftrags eines Kunden.
 
@@ -45,7 +43,7 @@ Aufgaben:
 2.  Erstellen Sie aus den ermittelten ÄK und GW konkrete Testfälle. (**Noch keine
     Implementierung!**)
 
-### A06.2: Mocking I
+# A06.2: Mocking I
 
 Implementieren Sie nun die in der vorigen Aufgabe ermittelten Testfälle für die Methode
 `Shop#accept` mit Hilfe von JUnit (Version 4 oder 5).
@@ -68,7 +66,7 @@ JUnit5-Bibliothek automatisch zur Verfügung. Wenn Sie JUnit4 nutzen möchten, m
 die Gradle-Konfiguration entsprechend anpassen. Mit `./gradlew test` können Sie Ihre Testfälle
 ausführen.
 
-### A06.3: Mocking II
+# A06.3: Mocking II
 
 Die Methoden `Shop#repair` und `Shop#deliver` sind auch noch nicht implementiert. Nutzen Sie
 geeignetes Mocking, um für diese beiden Methoden Tests in JUnit zu implementieren. Begründen
@@ -76,7 +74,7 @@ Sie die Anwendung von Mockito.
 
 *Hinweis*: Sie *müssen* hier keine ÄK/GW-Analyse machen, können das aber natürlich gern tun.
 
-### A06.4: Record-Klassen
+# A06.4: Record-Klassen
 
 Die Klasse `Order` ist zwar bisher nur unvollständig implementiert, aber Sie können bereits
 deutlich erkennen, dass es zwei Attribute geben muss (welche?).
@@ -85,7 +83,7 @@ Bauen Sie die Klasse in eine passende Record-Klasse mit den entsprechenden Attri
 dürfen die beiden Methoden in `Order` auch geeignet "implementieren" und umbenennen - die
 Umbenennung muss dann aber auch in den Aufrufen in `Shop` und in Ihren JUnit-Tests passieren!
 
-### A06.5: Logging
+# A06.5: Logging
 
 Bauen Sie für den `Shop` ein Logging auf der Basis von `java.util.logging` ein: Jede Änderung
 an der Auftrags-Warteschlange `pendingOrders` und auch an der Menge der fertigen Aufträge

--- a/homework/b07.md
+++ b/homework/b07.md
@@ -8,7 +8,7 @@ attachments:
 
 <!--  pandoc -s -f markdown -t markdown+smart-grid_tables-multiline_tables-simple_tables --columns=94 --reference-links=true  b07.md  -o xxx.md  -->
 
-## A07.1: Javadoc-Kommentare
+# A07.1: Javadoc-Kommentare
 
 Gute Javadoc-Kommentare schreiben erfordert Übung. Schauen Sie sich die in Commit
 [Dungeon-CampusMinden/Dungeon/commit/46530b6] neu hinzugefügte Datei
@@ -17,14 +17,14 @@ Gute Javadoc-Kommentare schreiben erfordert Übung. Schauen Sie sich die in Comm
 Diskutieren Sie jeweils, was Ihnen an der Dokumentation dieser Klasse auffällt: Was gefällt
 Ihnen, was stört Sie? Schlagen Sie Verbesserungen vor.
 
-## DevDungeon: Illusion Riddle
+# DevDungeon: Illusion Riddle
 
 Klonen Sie das Projekt [DevDungeon] und laden Sie es in Ihrer IDE als Gradle-Projekt.
 Betrachten Sie das Sub-Projekt "devDungeon". Dies ist ein von einem Studierenden ([\@Flamtky])
 erstelltes Spiel mit mehreren Leveln, in denen Sie spielerisch verschiedene Aufgaben *in-game*
 und *ex-game* lösen müssen.
 
-### A07.2: DevDungeon: Lösen des Illusion Riddle
+## A07.2: DevDungeon: Lösen des Illusion Riddle
 
 Starten Sie den DevDungeon mit `./gradlew devDungeon:runDevDungeon`. Spielen Sie sich für
 diese Aufgabe durch das **dritte Level** ("Illusion Riddle")[^1].
@@ -66,7 +66,7 @@ Task `devDungeon:runDevDungeon` aus der IDE heraus) starten.
 Sonderzeichen (Umlaute o.ä.) vorkommen! Dies kann zu seltsamen Fehler führen. Bitte auch
 darauf achten, dass Sie als JDK ein **Java SE 21 (LTS)** verwenden.
 
-### A07.3: DevDungeon: Refactoring der Klasse IllusionRiddleLevel
+## A07.3: DevDungeon: Refactoring der Klasse IllusionRiddleLevel
 
 Analysieren Sie die Klasse `IllusionRiddleLevel` im Package `level.devlevel`, insbesondere die
 beiden Methoden `IllusionRiddleLevel#onTick` und `IllusionRiddleLevel#lightTorch`:
@@ -89,7 +89,7 @@ beginnen. Leider ist durch die Abhängigkeit zu libGDX und der Game-Loop das Tes
 Dungeon nicht trivial, so dass Sie hier ausnahmsweise direkt mit dem Refactoring loslegen
 dürfen und auf das Erstellen einer Testsuite verzichten können.
 
-### A07.4: Protector-Skill für Ihren Hero
+## A07.4: Protector-Skill für Ihren Hero
 
 Erstellen Sie einen neuen Protector-Skill für den Hero und weisen Sie diesen einer Taste zu.
 Bei Nutzung des Skills soll ein neues Protector-Monster an einer zufälligen Position in einem
@@ -105,7 +105,7 @@ dadurch leichter zum Ausgang des Levels kommen.
 **Hinweis**: Erinnern Sie sich an die [ECS-Architektur]. Schauen Sie sich u.a. die Factory
 `HeroFactory` und den `FireballSkill` an.
 
-## A07.5: Refactoring im Bike-Shop
+# A07.5: Refactoring im Bike-Shop
 
 Forken Sie das [Refactoring]-Repo und erzeugen Sie sich eine lokale Arbeitskopie von Ihrem
 Fork. Analysieren Sie die Klassen im Package `refactoring`. Sie finden unübersichtlichen und

--- a/homework/b08.md
+++ b/homework/b08.md
@@ -9,7 +9,7 @@ attachments:
 
 <!--  pandoc -s -f markdown -t markdown+smart-grid_tables-multiline_tables-simple_tables --columns=94 --reference-links=true  b08.md  -o xxx.md  -->
 
-## DevDungeon: Brücken-Troll
+# DevDungeon: Brücken-Troll
 
 Klonen Sie das Projekt [DevDungeon] und laden Sie es in Ihrer IDE als Gradle-Projekt.
 Betrachten Sie das Sub-Projekt "devDungeon". Dies ist ein von einem Studierenden ([\@Flamtky])
@@ -43,7 +43,7 @@ Task `devDungeon:runDevDungeon` aus der IDE heraus) starten.
 Sonderzeichen (Umlaute o.ä.) vorkommen! Dies kann zu seltsamen Fehler führen. Bitte auch
 darauf achten, dass Sie als JDK ein **Java SE 21 (LTS)** verwenden.
 
-### A08.1: RegExp mit dem Brücken-Troll
+## A08.1: RegExp mit dem Brücken-Troll
 
 Suchen Sie den Brücken-Troll auf und sprechen Sie ihn an. Er wird Ihnen eine Reihe von Fragen
 zum Thema reguläre Ausdrücke stellen, die Sie korrekt beantworten müssen.
@@ -51,7 +51,7 @@ zum Thema reguläre Ausdrücke stellen, die Sie korrekt beantworten müssen.
 Machen Sie Screenshots von den Fragen und Ihren Antworten, die Sie im Praktikum vorstellen und
 diskutieren.
 
-### A08.2: Command-Pattern mit der Klasse *BridgeControlCommand*
+## A08.2: Command-Pattern mit der Klasse *BridgeControlCommand*
 
 Leider lässt sich der Brücken-Troll offenbar weder durch Diskussion noch durch Kampf besiegen.
 Aber vielleicht können Sie die Brücke "aufmachen", so dass er in die Tiefe stürzt? Die *Tiles*
@@ -71,7 +71,7 @@ Implementieren Sie die beiden Methoden und starten Sie das Spiel erneut.
 **Hinweis**: Mit der Methode `Game.currentLevel().tileAt()` können Sie auf ein `Tile` an einer
 bestimmte Koordinate zugreifen.
 
-## A08.3: Syntaxhighlighting mit RegExp
+# A08.3: Syntaxhighlighting mit RegExp
 
 Klonen Sie die [Vorgaben "Syntax Highlighting"] und laden Sie das Projekt als Gradle-Projekt
 in Ihre IDE.

--- a/homework/b09.md
+++ b/homework/b09.md
@@ -8,13 +8,11 @@ attachments:
 
 <!--  pandoc -s -f markdown -t markdown+smart-grid_tables-multiline_tables-simple_tables --columns=94 --reference-links=true  b09.md  -o xxx.md  -->
 
-## Zoo
-
 Sie finden in den [Vorgaben] im Package `zoo` einige Interfaces und Klassen, mit denen man
 einen Zoo modellieren kann. Klonen Sie das Vorgabe-Repo und laden Sie das Projekt als
 Gradle-Projekt in Ihre IDE.
 
-### A09.1: Nicht-generische Klassen
+# A09.1: Nicht-generische Klassen
 
 Sie finden einige Interfaces, die das Interface `Animal` erweitern, beispielsweise `Fish`,
 `Reptile`, `Cat`, ...
@@ -32,7 +30,7 @@ ein kurzer Name, beispielsweise der Tierklasse, zurückgegeben werden.
 Sie in Ihren Klassen nicht implementieren. Wir werden später im Semester noch über die
 sogenannten ["Default-Methoden"] sprechen.
 
-### A09.2: Generische Klassen
+# A09.2: Generische Klassen
 
 Um Gehege zu modellieren, erstellen Sie in eine generische Klasse `Habitat` mit einer
 Typ-Variablen. Stellen Sie durch geeignete Beschränkung der Typ-Variablen sicher, dass nur
@@ -54,7 +52,7 @@ generischen Klasse `Habitat` an. Dabei sollen in diesen konkreten Gehegen nur je
 verschiedene Tiere einer "Art" (beispielweise Löwen, Hamster, ...) vorkommen. Fügen Sie einige
 passende Tiere in die beiden Gehege ein.
 
-### A09.3: Generische Klassen reloaded
+# A09.3: Generische Klassen reloaded
 
 Für die Repräsentation eines Zoologischen Gartens mit mehreren verschiedenen Gehegen erstellen
 Sie nun eine generische Klasse `Zoo` mit einer Typ-Variablen. Stellen Sie durch geeignete
@@ -76,7 +74,7 @@ eine Ordnung auf den Gehegen. Begründen Sie die Wahl der Datenstruktur.
 Legen Sie in Ihrer `main()`-Methode einen konkreten Zoo als Instanz der neuen generischen
 Klasse `Zoo` an. Dieser Zoo soll einige Gehege für verschiedene Tiere beinhalten.
 
-### A09.4: Ableiten nicht-generischer Klassen
+# A09.4: Ableiten nicht-generischer Klassen
 
 Leiten Sie von `Zoo` eine nicht-generische Klasse `Aquarium` ab. Aquarien können nur mit
 Gehegen angelegt werden, deren Tiere vom Typ `Fish` (oder abgeleitet) sind.

--- a/lecture/building/ant.md
+++ b/lecture/building/ant.md
@@ -50,7 +50,7 @@ fhmedia:
 ---
 
 
-## Automatisieren von Arbeitsabläufen
+# Automatisieren von Arbeitsabläufen
 
 ::: center
 Works on my machine ...
@@ -80,7 +80,7 @@ Works on my machine ...
 :::
 
 
-## Aufbau von Ant-Skripten: Projekte und Targets
+# Aufbau von Ant-Skripten: Projekte und Targets
 
 ```xml
 <project name="Vorlesung" default="clean" basedir=".">
@@ -100,7 +100,7 @@ Works on my machine ...
 :::
 
 
-## Aufgaben erledigen: Tasks
+# Aufgaben erledigen: Tasks
 
 ::: notes
 *   **Tasks**: Aufgaben bzw. Befehle ("Methodenaufruf"), in Targets auszuführen
@@ -127,7 +127,7 @@ Works on my machine ...
 [Konsole/IDE: ant -f hello.xml]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/building/src/ant/hello.xml"}
 
 
-## Properties: Name-Wert-Paare
+# Properties: Name-Wert-Paare
 
 ```xml
 <property name="app"       value="MyProject" />
@@ -157,7 +157,7 @@ Works on my machine ...
 :::
 
 
-## Tasks zum Umgang mit Dateien und Ordnern
+# Tasks zum Umgang mit Dateien und Ordnern
 
 ```xml
 <target name="demo">
@@ -184,7 +184,7 @@ Works on my machine ...
 :::
 
 
-## Nutzung von Filesets in Tasks
+# Nutzung von Filesets in Tasks
 
 ```xml
 <copy todir="archive">
@@ -211,7 +211,7 @@ gruppieren.
 :::
 
 
-## Pfade und externe Bibliotheken
+# Pfade und externe Bibliotheken
 
 *   Als Element direkt im Task:
 
@@ -288,9 +288,9 @@ Für JUnit5 gibt es einen neuen Task `JUnitLauncher` (vgl.
 
 
 ::::::::: notes
-## Beispiele
+# Beispiele
 
-### Beispiel-Task: Kompilieren
+## Beispiel-Task: Kompilieren
 
 ```xml
 <path id="project.classpath">
@@ -304,7 +304,7 @@ Für JUnit5 gibt es einen neuen Task `JUnitLauncher` (vgl.
 </target>
 ```
 
-### Beispiel-Task: Packen
+## Beispiel-Task: Packen
 
 ```xml
 <target name="dist" depends="compile" description="generate the distribution" >
@@ -317,7 +317,7 @@ Für JUnit5 gibt es einen neuen Task `JUnitLauncher` (vgl.
 </target>
 ```
 
-### Beispiel-Task: Testen
+## Beispiel-Task: Testen
 
 *   Tests einer Testklasse ausführen:
 
@@ -381,7 +381,7 @@ Für JUnit5 gibt es einen neuen Task `JUnitLauncher` (vgl.
 
 => `junit.jar` und `ant-junit.jar` (JUnit4.x) im Pfad!
 
-### Programme ausführen
+## Programme ausführen
 
 ```xml
 <target name="run">
@@ -396,7 +396,7 @@ Für JUnit5 gibt es einen neuen Task `JUnitLauncher` (vgl.
 :::::::::
 
 
-## Ausblick: Laden von Abhängigkeiten mit Apache Ivy
+# Ausblick: Laden von Abhängigkeiten mit Apache Ivy
 
 ::: notes
 [Apache Ivy](https://ant.apache.org/ivy/): Dependency Manager für Ant
@@ -468,7 +468,7 @@ Ivy-Cache unter ~/.ivy2/cache/
 [Demo: ivydemo.xml]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/building/src/ant/ivydemo.xml"}
 
 
-## Ausblick: Weitere Build-Systeme
+# Ausblick: Weitere Build-Systeme
 
 *   [Maven](https://maven.apache.org/)
     *   War als Nachfolger von Ant gedacht
@@ -489,7 +489,7 @@ Ivy-Cache unter ~/.ivy2/cache/
     *   Analog zu Ant: Aktionen und Ziele müssen explizit definiert werden
 
 
-## Wrap-Up
+# Wrap-Up
 
 Apache Ant: [ant.apache.org](https://ant.apache.org/)
 

--- a/lecture/building/ci.md
+++ b/lecture/building/ci.md
@@ -101,23 +101,23 @@ challenges: |
 
 
 ::::::::: notes
-## Motivation: Zusammenarbeit in Teams
+# Motivation: Zusammenarbeit in Teams
 
-### Szenario
+## Szenario
 
 *   Projekt besteht aus diversen Teilprojekten
 *   Verschiedene Entwicklungs-Teams arbeiten (getrennt) an verschiedenen Projekten
 *   Tester entwickeln Testsuiten für die Teilprojekte
 *   Tester entwickeln Testsuiten für das Gesamtprojekt
 
-### Manuelle Ausführung der Testsuiten reicht nicht
+## Manuelle Ausführung der Testsuiten reicht nicht
 
 *   Belastet den Entwicklungsprozess
 *   Keine (einheitliche) Veröffentlichung der Ergebnisse
 *   Keine (einheitliche) Eskalation bei Fehlern
 *   Keine regelmäßige Integration in Gesamtprojekt
 
-### Continuous Integration
+## Continuous Integration
 
 *   Regelmäßige, automatische Ausführung: Build und Tests
 *   Reporting
@@ -125,12 +125,12 @@ challenges: |
 :::::::::
 
 
-## Continuous Integration (CI)
+# Continuous Integration (CI)
 
 ![](images/ci.png){width="80%" web_width="60%"}
 
 ::::::::: notes
-### Vorgehen
+## Vorgehen
 
 *   Entwickler und Tester committen ihre Änderungen regelmäßig (Git, SVN, ...)
 *   CI-Server arbeitet Build-Skripte ab, getriggert durch Events: Push-Events, Zeit/Datum, ...
@@ -141,14 +141,14 @@ challenges: |
     *   Typische weitere Builds: "Nightly Build", Release-Build, ...
     *   Ergebnisse jeweils auf der Weboberfläche einsehbar (und per E-Mail)
 
-### Einige Vorteile
+## Einige Vorteile
 
 *   Tests werden regelmäßig durchgeführt (auch wenn sie lange dauern oder die
     Maschine stark belasten)
 *   Es wird regelmäßig ein Gesamt-Build durchgeführt
 *   Alle Teilnehmer sind über aktuellen Projekt(-zu-)stand informiert
 
-### Beispiele für verbreitete CI-Umgebungen
+## Beispiele für verbreitete CI-Umgebungen
 
 *   [Jenkins](https://www.jenkins.io/)
 *   [GitLab CI/CD](https://docs.gitlab.com/ee/ci/)
@@ -161,13 +161,13 @@ challenges: |
 
 
 ::::::::: notes
-## GitLab CI/CD
+# GitLab CI/CD
 
 Siehe auch ["Get started with Gitlab CI/CD"](http://git03-ifm-min.ad.hsbi.de/help/ci/quick_start/index.md).
 (Für den Zugriff wird VPN benötigt!)
 
 
-### Übersicht über Pipelines
+## Übersicht über Pipelines
 
 ![](images/screenshot-gitlabci-pipelines.png){width="70%" web_width="60%"}
 
@@ -182,14 +182,14 @@ Siehe auch ["Get started with Gitlab CI/CD"](http://git03-ifm-min.ad.hsbi.de/hel
 Wenn man mit der Maus auf den Status oder die Stages geht, erfährt man mehr bzw.
 kann auf eine Seite mit mehr Informationen kommen.
 
-### Detailansicht einer Pipeline
+## Detailansicht einer Pipeline
 
 ![](images/screenshot-gitlabci-triggeredpipeline.png){width="70%" web_width="60%"}
 
 Wenn man in eine Pipeline in der Übersicht klickt, werden die einzelnen
 Stages dieser Pipeline genauer dargestellt.
 
-### Detailansicht eines Jobs
+## Detailansicht eines Jobs
 
 ![](images/screenshot-gitlabci-job.png){width="70%" web_width="60%"}
 
@@ -197,7 +197,7 @@ Wenn man in einen Job einer Stage klickt, bekommt man quasi die Konsolenausgabe
 dieses Jobs. Hier kann man ggf. Fehler beim Ausführen der einzelnen Skripte
 oder die Ergebnisse beispielsweise der JUnit-Läufe anschauen.
 
-### GitLab CI/CD: Konfiguration mit YAML-Datei
+## GitLab CI/CD: Konfiguration mit YAML-Datei
 
 Datei `.gitlab-ci.yml` im Projekt-Ordner:
 
@@ -225,7 +225,7 @@ job3:
     stage: my.compile
 ```
 
-#### Stages
+### Stages
 
 Unter `stages` werden die einzelnen Stages einer Pipeline definiert. Diese werden
 in der hier spezifizierten Reihenfolge durchgeführt, d.h. zuerst würde `my.compile`
@@ -241,7 +241,7 @@ Wenn keine eigenen `stages` definiert werden, kann man
 auf die Default-Stages `build`, `test` und `deploy` zurückgreifen. **Achtung**: Sobald
 man eigene Stages definiert, stehen diese Default-Stages *nicht* mehr zur Verfügung!
 
-#### Jobs
+### Jobs
 
 `job1`, `job2` und `job3` definieren jeweils einen Job.
 
@@ -267,7 +267,7 @@ Durch die Kombination von Jobs mit der Zuordnung zu Stages und Events lassen
 sich unterschiedliche Pipelines für verschiedene Zwecke definieren.
 
 
-### Hinweise zur Konfiguration von GitLab CI/CD
+## Hinweise zur Konfiguration von GitLab CI/CD
 
 Im Browser in den Repo-Einstellungen arbeiten:
 
@@ -300,13 +300,13 @@ _Optional_:
 
 
 ::::::::: notes
-## GitHub Actions
+# GitHub Actions
 
 Siehe ["GitHub Actions: Automate your workflow from idea to production"](https://github.com/features/actions)
 und auch ["GitHub: CI/CD explained"](https://resources.github.com/ci-cd/).
 
 
-### Übersicht über Workflows
+## Übersicht über Workflows
 
 ![](images/screenshot-githubci-workflows.png){width="70%" web_width="60%"}
 
@@ -318,7 +318,7 @@ Event filtern.
 In der Abbildung ist ein Workflow mit dem Namen "GitHub CI" zu sehen, der
 aktuell noch läuft.
 
-### Detailansicht eines Workflows
+## Detailansicht eines Workflows
 
 ![](images/screenshot-githubci-triggeredworkflow.png){width="70%" web_width="60%"}
 
@@ -327,7 +327,7 @@ Jobs dieses Workflows genauer dargestellt. "job3" ist erfolgreich gelaufen, "job
 läuft gerade, und "job2" hängt von "job1" ab, d.h. kann erst nach dem erfolgreichen
 Lauf von "job2" starten.
 
-### Detailansicht eines Jobs
+## Detailansicht eines Jobs
 
 ![](images/screenshot-githubci-job.png){width="70%" web_width="60%"}
 
@@ -335,7 +335,7 @@ Wenn man in einen Job anklickt, bekommt man quasi die Konsolenausgabe
 dieses Jobs. Hier kann man ggf. Fehler beim Ausführen der einzelnen Skripte
 oder die Ergebnisse beispielsweise der JUnit-Läufe anschauen.
 
-### GitHub Actions: Konfiguration mit YAML-Datei
+## GitHub Actions: Konfiguration mit YAML-Datei
 
 Workflows werden als YAML-Dateien im Ordner `.github/workflows/` angelegt.
 
@@ -382,7 +382,7 @@ jobs:
       - run: echo "Job 3"
 ```
 
-#### Workflowname und Trigger-Events
+### Workflowname und Trigger-Events
 
 Der Name des Workflows wird mit dem Eintrag `name` spezifiziert und sollte sich im
 Dateinamen widerspiegeln, also im Beispiel `.github/workflows/github_ci.yml`.
@@ -391,7 +391,7 @@ Im Eintrag `on` können die Events definiert werden, die den Workflow triggern. 
 Beispiel ist ein Push-Event auf dem `master`-Branch definiert sowie mit `workflow_dispatch:`
 das manuelle Triggern (auf einem beliebigen Branch) freigeschaltet.
 
-#### Jobs
+### Jobs
 
 Die Jobs werden unter dem Eintrag `jobs` definiert: `job1`, `job2` und `job3` definieren
 jeweils einen Job.
@@ -431,7 +431,7 @@ Man kann auch einen Docker-Container benutzen. Dabei muss man beachten, dass die
 aus einer Registry (etwa von Docker-Hub oder aus der GitHub-Registry) "gezogen" wird, weil das
 Bauen des Docker-Containers aus einem Docker-File in der Action u.U. relativ lange dauert.
 
-### Hinweise zur Konfiguration von GitHub Actions
+## Hinweise zur Konfiguration von GitHub Actions
 
 Im Browser in den Repo-Einstellungen arbeiten:
 
@@ -451,7 +451,7 @@ Im Browser in den Repo-Einstellungen arbeiten:
 :::::::::
 
 
-## Wrap-Up
+# Wrap-Up
 
 Überblick über Continuous Integration:
 

--- a/lecture/building/docker.md
+++ b/lecture/building/docker.md
@@ -69,7 +69,7 @@ attachments:
 
 
 
-## Motivation CI/CD: WFM (_Works For Me_)
+# Motivation CI/CD: WFM (_Works For Me_)
 
 ![](images/ci.png){width="80%" web_width="60%"}
 
@@ -99,7 +99,7 @@ In diesen Fällen kann eine Virtualisierung helfen.
 :::
 
 
-## Virtualisierung: Container vs. VM
+# Virtualisierung: Container vs. VM
 
 ![](images/virtualisierung.png){width="80%" web_width="60%"}
 
@@ -143,7 +143,7 @@ normalerweise keine VMs/Container basierend auf ARM-Architektur ausgeführt werd
 :::
 
 
-## Getting started
+# Getting started
 
 *   DockerHub: fertige Images => [hub.docker.com/search](https://hub.docker.com/search?q=&type=image)
 
@@ -153,7 +153,7 @@ normalerweise keine VMs/Container basierend auf ARM-Architektur ausgeführt werd
 *   Image starten: `docker run <IMAGE>`
 
 ::: notes
-### Begriffe
+## Begriffe
 
 *   **Docker-File**: Beschreibungsdatei, wie Docker ein Image erzeugen soll.
 *   **Image**: Enthält die Dinge, die lt. dem Docker-File in das Image gepackt werden sollen.
@@ -161,7 +161,7 @@ normalerweise keine VMs/Container basierend auf ARM-Architektur ausgeführt werd
 *   **Container**: Ein laufendes Images (genauer: eine laufende Instanz eines Images). Kann
     dann auch zusätzliche Daten enthalten.
 
-### Beispiele
+## Beispiele
 :::
 
 ::: slides
@@ -229,7 +229,7 @@ dann mit `java Hello` die Klasse ausgeführt werden.
 [Demo: Container in der Konsole]{.ex href="https://youtu.be/LE_QcHqUg9Y"}
 
 
-## Images selbst definieren
+# Images selbst definieren
 
 ```docker
 FROM debian:stable-slim
@@ -295,7 +295,7 @@ und erstellt ein neues, welches dann die aktualisierte Software enthält.
 [Beispiel: debian-latex.df]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/building/src/docker/debian-latex.df"}
 
 
-## CI-Pipeline (GitLab)
+# CI-Pipeline (GitLab)
 
 ```yaml
 default:
@@ -324,7 +324,7 @@ Containers gesendet. Im Prinzip entspricht das dem Aufruf auf dem lokalen Rechne
 [Demo: GitLab CI/CD und Docker]{.ex href="https://youtu.be/3Tj3lhcoKro"}
 
 
-## CI-Pipeline (GitHub)
+# CI-Pipeline (GitHub)
 
 ```yaml
 name: demo
@@ -360,7 +360,7 @@ Im Prinzip entspricht das dem Aufruf auf dem lokalen Rechner: `docker run openjd
 [Demo: GitHub Actions und Docker]{.ex href="https://youtu.be/jrxoax2fPRI"}
 
 
-## VSCode und das Plugin "Remote - Containers"
+# VSCode und das Plugin "Remote - Containers"
 
 ![](images/vscode-remote.png){width="80%"}
 
@@ -407,7 +407,7 @@ von GitHub auf.
 
 
 ::::::::: notes
-## Link-Sammlung
+# Link-Sammlung
 
 *   [Wikipedia: Docker](https://en.wikipedia.org/wiki/Docker_(software))
 *   [Wikipedia: Virtuelle Maschinen](https://en.wikipedia.org/wiki/Virtual_machine)
@@ -422,7 +422,7 @@ von GitHub auf.
 :::::::::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Schlanke Virtualisierung mit Containern (kein eigenes OS)
 *   _Kein_ Sandbox-Effekt

--- a/lecture/building/gradle.md
+++ b/lecture/building/gradle.md
@@ -47,7 +47,7 @@ challenges: |
 ---
 
 
-## Automatisieren von Arbeitsabläufen
+# Automatisieren von Arbeitsabläufen
 
 ::: center
 Works on my machine ...
@@ -106,7 +106,7 @@ Vorteil ist aber der Gradle-Wrapper (s.u.).
 :::
 
 
-## Gradle: Eine DSL in Groovy
+# Gradle: Eine DSL in Groovy
 
 [DSL: _Domain Specific Language_]{.notes}
 
@@ -151,7 +151,7 @@ Eintrag `application` den Einsprungpunkt in die Applikation konfigurieren.
 
 
 :::::::::  notes
-## Gradle-DSL
+# Gradle-DSL
 
 <!-- Für die Demos:
 docker pull gradle
@@ -165,7 +165,7 @@ der JVM ausgeführte Skriptsprache. Seit einigen Versionen kann man die
 Gradle-Build-Skripte auch in der Sprache Kotlin schreiben.
 
 
-## Dateien
+# Dateien
 
 Für das Bauen mit Gradle benötigt man drei Dateien im Projektordner:
 
@@ -184,7 +184,7 @@ Für das Bauen mit Gradle benötigt man drei Dateien im Projektordner:
     Properties für den Gradle-Build spezifizieren kann.
 
 
-## Gradle Init
+# Gradle Init
 
 Um eine neue Gradle-Konfiguration anlegen zu lassen, geht man in einen Ordner
 und führt darin `gradle init` aus. Gradle fragt der Reihe nach einige Einstellungen
@@ -238,7 +238,7 @@ verwendet werden soll.
 Damit wird die eingangs gezeigte Konfiguration angelegt.
 
 
-## Ordner
+# Ordner
 
 Durch `gradle init` wird ein neuer Ordner `wuppie/` mit folgender Ordnerstruktur
 angelegt:
@@ -336,7 +336,7 @@ sourceSets {
 
 
 :::::::::  slides
-## Wichtige Gradle-Tasks
+# Wichtige Gradle-Tasks
 
 *   Initialisieren des Projekts: `gradle init`
 
@@ -354,7 +354,7 @@ sourceSets {
 
 
 :::::::::  notes
-## Ablauf eines Gradle-Builds
+# Ablauf eines Gradle-Builds
 
 Ein Gradle-Build hat zwei Hauptphasen: Konfiguration und Ausführung.
 
@@ -377,7 +377,7 @@ die Anwendung in ein `.jar`-File packen und mit `gradle javadoc` die Javadoc-Dok
 erzeugen und mit `gradle clean` die generierten Hilfsdateien aufräumen (löschen).
 
 
-## Plugin-Architektur
+# Plugin-Architektur
 
 Für bestimmte Projekttypen gibt es immer wieder die gleichen Aufgaben. Um hier
 Schreibaufwand zu sparen, existieren verschiedene Plugins für verschiedene
@@ -393,7 +393,7 @@ ausführt ...
 Sie können sich Plugins und weitere Tasks relativ leicht auch selbst definieren.
 
 
-## Auflösen von Abhängigkeiten
+# Auflösen von Abhängigkeiten
 
 Analog zu Maven kann man Abhängigkeiten (etwa in einer bestimmten Version
 benötigte Bibliotheken) im Gradle-Skript angeben. Diese werden (transparent für
@@ -417,7 +417,7 @@ Die Einträge in `dependencies` erfolgen dabei in einer Maven-Notation, die Sie
 auch im Maven-Repo [mvnrepository.com](https://mvnrepository.com/) finden.
 
 
-## Beispiel mit weiteren Konfigurationen (u.a. Checkstyle und Javadoc)
+# Beispiel mit weiteren Konfigurationen (u.a. Checkstyle und Javadoc)
 
 ```groovy
 plugins {
@@ -476,7 +476,7 @@ Schreibweise sowohl in den generierten Builds-Skripten und in der offiziellen Do
 bevorzugt wird.
 
 
-## Gradle und Ant (und Maven)
+# Gradle und Ant (und Maven)
 
 Vorhandene Ant-Buildskripte kann man nach Gradle importieren und ausführen
 lassen. Über die DSL kann man auch direkt Ant-Tasks aufrufen. Siehe auch
@@ -484,7 +484,7 @@ lassen. Über die DSL kann man auch direkt Ant-Tasks aufrufen. Siehe auch
 :::::::::
 
 
-## Gradle-Wrapper
+# Gradle-Wrapper
 
 ```
 project
@@ -525,7 +525,7 @@ Deshalb ist der Einsatz des Wrappers einem fest installierten Gradle vorzuziehen
 [[Live-Demo Gradle/Gradlew]{.ex}]{.slides}
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Automatisieren von Arbeitsabläufen mit Build-Tools/-Skripten
 
@@ -538,7 +538,7 @@ Deshalb ist der Einsatz des Wrappers einem fest installierten Gradle vorzuziehen
 
 
 ::::::::: notes
-## Link-Sammlung Gradle
+# Link-Sammlung Gradle
 
 *   ["Getting Started"](https://docs.gradle.org/current/userguide/getting_started.html)
 *   ["Building Java Applications Sample"](https://docs.gradle.org/current/samples/sample_building_java_applications.html)

--- a/lecture/building/maven.md
+++ b/lecture/building/maven.md
@@ -38,7 +38,7 @@ fhmedia:
 ---
 
 
-## Build-Tool Maven: Alternative zu Ant oder Gradle
+# Build-Tool Maven: Alternative zu Ant oder Gradle
 
 ```maven
 mvn archetype:generate -DgroupId=de.hsbi.pm -DartifactId=my-project
@@ -79,7 +79,7 @@ genutzt. Von hier würde Maven auch als Abhängigkeit konfigurierte Bibliotheken
 :::
 
 
-## Lebenszyklus (eingebaut in Maven)
+# Lebenszyklus (eingebaut in Maven)
 
 ![](images/screenshot_maven-lifecycle.png){width="80%"}
 
@@ -91,7 +91,7 @@ auch die Abhängigkeiten berücksichtigt, d.h. das Ziel `test` erfordert ein `co
 :::
 
 
-## Project Object Model: *pom.xml*
+# Project Object Model: *pom.xml*
 
 ```xml
 <project>
@@ -142,7 +142,7 @@ für die Dependencies findet man ebenfalls auf [MavenCentral](https://mvnreposit
 [[Demo für MavenCentral (Suche, Einträge)]{.ex}]{.slides}
 
 
-## Project Object Model: Plugins
+# Project Object Model: Plugins
 
 ```xml
 <project>
@@ -186,7 +186,7 @@ ein erster Einstieg ist die [Plugin-API](https://maven.apache.org/ref/3.8.1/mave
 
 
 ::: notes
-## Und wie lasse ich jetzt eine Anwendung mal laufen?
+# Und wie lasse ich jetzt eine Anwendung mal laufen?
 
 *   `mvn clean`: Lösche alle generierten Artefakte, beispielsweise `.class`-Dateien.
 *   `mvn compile` => `mvn compiler:compile`: Übersetze die Sourcen und schiebe die
@@ -208,7 +208,7 @@ ein erster Einstieg ist die [Plugin-API](https://maven.apache.org/ref/3.8.1/mave
 [Demo: pom.xml]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/building/src/maven/pom.xml"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 Apache Maven: [maven.apache.org](https://maven.apache.org), [Maven Getting Started Guide](https://maven.apache.org/guides/getting-started/index.html)
 

--- a/lecture/git/bisect.md
+++ b/lecture/git/bisect.md
@@ -39,10 +39,10 @@ fhmedia:
 ---
 
 
-## Git Bisect: Wer hats wann kaputt gespielt?
+# Git Bisect: Wer hats wann kaputt gespielt?
 
 ::::::::: notes
-### Szenario
+## Szenario
 
 *   Sie haben eine Software ausgeliefert, die offenbar gut funktioniert.
 *   Sie erweitern die Software und testen intern mit JUnit.
@@ -57,7 +57,7 @@ fhmedia:
 
 => Hier schlägt die Stunde von Git Bisect :-)
 
-### Arbeitsweise
+## Arbeitsweise
 :::::::::
 
 
@@ -83,7 +83,7 @@ fhmedia:
 
 
 ::::::::: notes
-### Anmerkungen
+## Anmerkungen
 
 *   Geht auch mit `new`/`old` (statt `good`/`bad`)
 *   Suche kann auch automatisiert werden: `git bisect run <my_script> <arguments>`
@@ -96,13 +96,13 @@ fhmedia:
     dann kann man einen in der Nähe liegenden Commit als Ersatz
     auswählen lassen: `git bisect skip`
 
-### Tutorial
+## Tutorial
 
 Ein schönes Tutorial finden Sie auf
 ["A beginner's guide to GIT BISECT - The process of elimination"](https://www.metaltoad.com/blog/beginners-guide-git-bisect-process-elimination).
 :::::::::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Git Bisect: Finde Commit, der einen Fehler einführt (Halbierungs-Suche)

--- a/lecture/git/branches.md
+++ b/lecture/git/branches.md
@@ -108,7 +108,7 @@ challenges: |
 ---
 
 
-## Neues Feature entwickeln/ausprobieren
+# Neues Feature entwickeln/ausprobieren
 
     A---B---C  master
 
@@ -168,7 +168,7 @@ bisherige Befehl "`checkout`" funktioniert aber weiterhin.
 [[Konsole]{.ex}]{.slides}
 
 
-## Arbeiten im Entwicklungszweig ...
+# Arbeiten im Entwicklungszweig ...
 
               D  wuppie
              /
@@ -185,7 +185,7 @@ bisherige Befehl "`checkout`" funktioniert aber weiterhin.
 :::
 
 
-## Problem: Fehler im ausgelieferten Produkt
+# Problem: Fehler im ausgelieferten Produkt
 
               D  wuppie
              /
@@ -225,7 +225,7 @@ auch Branches auf der Basis von `wuppie` anlegen ...
 :::
 
 
-## Fix ist stabil: Integration in _master_
+# Fix ist stabil: Integration in _master_
 
               D  wuppie
              /
@@ -276,7 +276,7 @@ Der letzte Schritt entfernt den Branch `fix`.
 :::
 
 
-## Feature weiter entwickeln ...
+# Feature weiter entwickeln ...
 
               D---F  wuppie
              /
@@ -300,7 +300,7 @@ einer Datei noch "`--`" nutzen: `git checkout -- <dateiname>`.
 :::
 
 
-## Feature ist stabil: Integration in _master_
+# Feature ist stabil: Integration in _master_
 
               D---F  wuppie                            D---F  wuppie
              /                     =>                 /     \
@@ -340,7 +340,7 @@ genauer: führt die Änderungen von `B` in `A` ein, d.h. der entsprechende Merge
 :::
 
 
-## Konflikte beim Mergen
+# Konflikte beim Mergen
 
 ::: notes
 (Parallele) Änderungen an selber Stelle => Merge-Konflikte
@@ -375,7 +375,7 @@ Git fügt Konflikt-Marker in die Datei ein:
 
 
 ::: notes
-## Merge-Konflikte auflösen
+# Merge-Konflikte auflösen
 
 Manuelles Editieren nötig (Auflösung des Konflikts):
 
@@ -392,7 +392,7 @@ Alternativ: Nutzung graphischer Oberflächen mittels `git mergetool`
 [Konsole: Branchen und Mergen]{.ex href="https://youtu.be/B8sesK1GyiE"}
 
 
-## Rebasen: Verschieben von Branches
+# Rebasen: Verschieben von Branches
 
               D---F  wuppie                            D---F  wuppie
              /                     =>                 /     \
@@ -454,7 +454,7 @@ und Message bleiben aber erhalten.)
 :::
 
 
-## Don't lose your HEAD
+# Don't lose your HEAD
 
 *   Branches sind wie Zeiger auf letzten Stand (Commit) eines Zweiges
 
@@ -481,7 +481,7 @@ und Message bleiben aber erhalten.)
 [[Konsole: Commit auschecken]{.ex}]{.slides}
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Anlegen von Branches mit `git branch`
 *   Umschalten der Workingcopy auf anderen Branch: `git checkout` oder `git switch`

--- a/lecture/git/branching-strategies.md
+++ b/lecture/git/branching-strategies.md
@@ -44,7 +44,7 @@ attachments:
 ---
 
 
-## Nutzung von Git in Projekten: Verteiltes Git (und Workflows)
+# Nutzung von Git in Projekten: Verteiltes Git (und Workflows)
 
 ![](images/distributed.png){width="80%" web_width="60%"}
 
@@ -57,7 +57,7 @@ Im Folgenden sollen also die Frage betrachtet werden: **Wie setze ich Branches s
 :::
 
 
-## Umgang mit Branches: Themen-Branches
+# Umgang mit Branches: Themen-Branches
 
                     I---J---K  wuppieV1
                    /
@@ -94,7 +94,7 @@ und der Themenbranch gelöscht.
 :::
 
 
-## Umgang mit Branches: Langlaufende Branches
+# Umgang mit Branches: Langlaufende Branches
 
     A---B---D  master
          \
@@ -133,7 +133,7 @@ Linux-Kernel.
 :::
 
 
-## Komplexe Branching-Strategie: Git-Flow
+# Komplexe Branching-Strategie: Git-Flow
 
     A---B---------------------G---J1  master
          \                   / \ /
@@ -157,7 +157,7 @@ Modells eigentlich nicht erklären :-)
 :::
 
 
-## Git-Flow: Hauptzweige _master_ und _develop_
+# Git-Flow: Hauptzweige _master_ und _develop_
 
     A---B-------E---------------J  master
          \     /               /
@@ -179,7 +179,7 @@ Entwicklungsarbeit mehr. Nach Fertigstellung wird der `release` dann sowohl in d
 :::
 
 
-## Git-Flow: Weitere Branches als Themen-Branches
+# Git-Flow: Weitere Branches als Themen-Branches
 
     A---B---------------------I-------------K  master
          \                   /             /
@@ -202,7 +202,7 @@ Arbeiten eine gewisse Reife haben, werden die Featurebranches in den
 
 
 ::::::::: notes
-## Git-Flow: Merging-Detail
+# Git-Flow: Merging-Detail
 
     ---C--------E  develop
         \      /                 git merge --no-ff
@@ -232,7 +232,7 @@ dass alle Commit-Kommentare zu einem Feature "A" mit "`feature a: `" starten mü
 :::::::::
 
 
-## Git-Flow: Umgang mit Fehlerbehebung
+# Git-Flow: Umgang mit Fehlerbehebung
 
     A---B---D--------F1  master
          \   \      /
@@ -252,7 +252,7 @@ Dadurch entspricht jeder Commit im `master` einem Release.
 :::
 
 
-## Vereinfachte Braching-Strategie: GitHub Flow
+# Vereinfachte Braching-Strategie: GitHub Flow
 
     A---B---C----D-----------E  master
          \   \  /           /
@@ -290,7 +290,7 @@ Weboberfläche erfolgt schließlich der Merge des Feature-Branches in den `maste
 
 
 ::: notes
-## Diskussion: Git-Flow vs. GitHub Flow
+# Diskussion: Git-Flow vs. GitHub Flow
 
 In der Praxis zeigt sich, dass das Git-Flow-Modell besonders gut geeignet ist,
 wenn man tatsächlich so etwas wie "Releases" hat, die zudem nicht zu häufig
@@ -319,7 +319,7 @@ Linux-Distribution die bessere sei):
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Einsatz von Themenbranches für die Entwicklung
 *   Unterschiedliche Modelle:

--- a/lecture/git/git-basics.md
+++ b/lecture/git/git-basics.md
@@ -76,7 +76,7 @@ challenges: |
 ---
 
 
-## Versionsverwaltung mit Git: Typische Arbeitsschritte
+# Versionsverwaltung mit Git: Typische Arbeitsschritte
 
 1.  Repository anlegen (oder clonen)
 
@@ -98,7 +98,7 @@ challenges: |
 9.  Änderungen verteilen (verteiltes Arbeiten, Workflows)
 
 
-## Dateien unter Versionskontrolle stellen
+# Dateien unter Versionskontrolle stellen
 
 \bigskip
 
@@ -123,7 +123,7 @@ challenges: |
 [[Konsole]{.ex}]{.slides}
 
 
-## Änderungen einpflegen
+# Änderungen einpflegen
 
 \bigskip
 
@@ -159,7 +159,7 @@ dabei außen vor!
 [[Konsole]{.ex}]{.slides}
 
 
-## Letzten Commit ergänzen
+# Letzten Commit ergänzen
 
 *   `git commit --amend -m "Eigentlich wollte ich das so sagen"`
 
@@ -182,7 +182,7 @@ dabei außen vor!
 
 
 ::: notes
-## Weitere Datei-Operationen: hinzufügen, umbenennen, löschen
+# Weitere Datei-Operationen: hinzufügen, umbenennen, löschen
 
 *   Neue (unversionierte) Dateien und Änderungen an versionierten Dateien zum Staging hinzufügen: `git add <file>`
 *   Löschen von Dateien (Repo+Workingcopy): `git rm <file>`
@@ -216,7 +216,7 @@ manuelles Umbenennen der Datei in der Workingcopy und `git add <fileNeu>`.
 :::
 
 
-## Commits betrachten
+# Commits betrachten
 
 *   Liste aller Commits: `git log`
     *   `git log -<n>` oder `git log --since="3 days ago"`
@@ -232,7 +232,7 @@ manuelles Umbenennen der Datei in der Workingcopy und `git add <fileNeu>`.
 [[Konsole]{.ex}]{.slides}
 
 
-## Änderungen und Logs betrachten
+# Änderungen und Logs betrachten
 
 *   `git diff [<file>]`
 
@@ -261,7 +261,7 @@ manuelles Umbenennen der Datei in der Workingcopy und `git add <fileNeu>`.
 [[Konsole]{.ex}]{.slides}
 
 
-## Dateien ignorieren: _.gitignore_
+# Dateien ignorieren: _.gitignore_
 
 ::: notes
 *   Nicht alle Dateien gehören ins Repo:
@@ -289,7 +289,7 @@ manuelles Umbenennen der Datei in der Workingcopy und `git add <fileNeu>`.
 [man 5 gitignore]{.ex href="https://linux.die.net/man/5/gitignore"}
 
 
-## Zeitmaschine
+# Zeitmaschine
 
 *   Änderungen in Workingcopy rückgängig machen
     *   Änderungen nicht in Stage: `git checkout <file>` oder `git restore <file>`
@@ -321,7 +321,7 @@ immer noch zur Verfügung und bietet über `git restore` hinaus weitere Anwendun
 [[Konsole]{.ex}]{.slides}
 
 
-## Wann und wie committen?
+# Wann und wie committen?
 
 \Large
 ::: center
@@ -356,7 +356,7 @@ keinen _atomic commit_ mehr vor sich.
 :::
 
 
-## Schreiben von Commit-Messages: WARUM?!
+# Schreiben von Commit-Messages: WARUM?!
 
 :::::: notes
 Schauen Sie sich einmal einen Screenshot eines `git log --oneline 61e48f0..e2c8076`
@@ -426,7 +426,7 @@ automatisch von Git aufgezeichnet ...)
 
 
 ::: notes
-## Ausflug "Conventional Commits"
+# Ausflug "Conventional Commits"
 
 Die Commit-Messages dienen vor allem der Dokumentation und werden von Entwicklern gelesen.
 
@@ -539,7 +539,7 @@ Schauen Sie sich beispielsweise einmal [gitmoji.dev](https://github.com/carloscu
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Änderungen einpflegen zweistufig (`add`, `commit`)
 *   Status der Workingcopy mit `status` ansehen

--- a/lecture/git/git-intro.md
+++ b/lecture/git/git-intro.md
@@ -47,7 +47,7 @@ attachments:
 ---
 
 
-## Typische Probleme bei SW-Entwicklung
+# Typische Probleme bei SW-Entwicklung
 
 *   Was hat wer wann (und wo) geändert? Und warum?
 *   Ich brauche den Stand von gestern/letzter Woche/...
@@ -57,7 +57,7 @@ attachments:
 *   Wir arbeiten am Release v42, aber Kunde braucht schnell einen Fix für v40
 
 
-## Folgen SW-Entwicklung ohne Versionsverwaltung
+# Folgen SW-Entwicklung ohne Versionsverwaltung
 
 ![](images/screenshot_zusammenarbeit_ohne_vcs.png){width=80% web_width="60%"}
 
@@ -72,7 +72,7 @@ attachments:
 :::
 
 
-## Prinzip Versionsverwaltung
+# Prinzip Versionsverwaltung
 
 :::::: columns
 ::: {.column width="48%"}
@@ -96,7 +96,7 @@ attachments:
 ::::::
 
 
-## Varianten: Zentrale Versionsverwaltung (Beispiel SVN)
+# Varianten: Zentrale Versionsverwaltung (Beispiel SVN)
 
 ![](images/centralised.png){width="80%" web_width="40%"}
 
@@ -110,7 +110,7 @@ eine Verbindung zum Server.
 :::
 
 
-## Varianten: Verteilte Versionsverwaltung (Beispiel Git)
+# Varianten: Verteilte Versionsverwaltung (Beispiel Git)
 
 ![](images/distributed.png){width="80%" web_width="60%"}
 
@@ -135,7 +135,7 @@ oder [Gitea](https://gitea.io/en-us/), wobei einige auch selbst gehostet werden 
 :::
 
 
-## Versionsverwaltung mit Git: Typische Arbeitsschritte
+# Versionsverwaltung mit Git: Typische Arbeitsschritte
 
 1.  Repository anlegen (oder clonen)
 
@@ -157,7 +157,7 @@ oder [Gitea](https://gitea.io/en-us/), wobei einige auch selbst gehostet werden 
 9.  Änderungen verteilen (verteiltes Arbeiten, Workflows)
 
 
-## (Globale) Konfiguration
+# (Globale) Konfiguration
 
 **Minimum**:
 
@@ -201,7 +201,7 @@ oder per Befehl `git config --global -l`.
 [[Konsole]{.ex}]{.slides}
 
 
-## Neues Repo anlegen
+# Neues Repo anlegen
 
 *   `git init`
 
@@ -216,7 +216,7 @@ oder per Befehl `git config --global -l`.
 [[Konsole]{.ex}]{.slides}
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Git: Versionsmanagement mit dezentralen Repositories
 *   Anlegen eines lokalen Repos mit `git init`

--- a/lecture/git/remotes.md
+++ b/lecture/git/remotes.md
@@ -91,7 +91,7 @@ challenges: |
 ---
 
 
-## Nutzung von Git in Projekten: Verteiltes Git (und Workflows)
+# Nutzung von Git in Projekten: Verteiltes Git (und Workflows)
 
 ![](images/distributed.png){width="80%"}
 
@@ -103,7 +103,7 @@ ich sinnvoll über Git mit anderen Kollegen und Teams zusammen? Welche Modelle h
 :::
 
 
-## Clonen kann sich lohnen ...
+# Clonen kann sich lohnen ...
 
     https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture
 
@@ -145,7 +145,7 @@ Für die URL sind verschiedene Protokolle möglich, beispielsweise:
 [[Hinweis auf Protokolle, Beispiel]{.ex}]{.slides}
 
 
-## Eigener und entfernter _master_ entwickeln sich weiter ...
+# Eigener und entfernter _master_ entwickeln sich weiter ...
 
     https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture
 
@@ -195,7 +195,7 @@ wurde, zeigt der remote Branch `origin/master` immer noch auf den Commit
 :::
 
 
-## Änderungen im Remote holen und Branches zusammenführen
+# Änderungen im Remote holen und Branches zusammenführen
 
     https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture
 
@@ -215,7 +215,7 @@ wurde, zeigt der remote Branch `origin/master` immer noch auf den Commit
 
 
 ::::::::: notes
-### Änderungen auf dem Server mit dem eigenen Repo abgleichen
+## Änderungen auf dem Server mit dem eigenen Repo abgleichen
 
 Mit `git fetch origin` alle Änderungen holen
 
@@ -230,7 +230,7 @@ Mit `git fetch origin` alle Änderungen holen
 *Wichtig*: Es werden nur die remote Branches aktualisiert, nicht die lokalen Branches!
 
 
-### _master_-Branch nach "git fetch origin" zusammenführen
+## _master_-Branch nach "git fetch origin" zusammenführen
 
 1.  Mit `git checkout master` Workingcopy auf eigenen `master` umstellen
 2.  Mit `git merge origin/master` Änderungen am `origin/master` in eigenen `master` mergen
@@ -263,7 +263,7 @@ mit der Option "`--rebase`" auf "rebase" umgestellt werden (per Default wird bei
 ein "merge" ausgeführt).
 
 
-### Auf dem Server ist nur ein _fast forward merge_ möglich
+## Auf dem Server ist nur ein _fast forward merge_ möglich
 
 Sie können Ihre Änderungen in Ihrem lokalen `master` auch direkt in das remote Repo
 pushen, solange auf dem Server ein **fast forward merge** möglich ist.
@@ -279,7 +279,7 @@ werden).
 [Beispiel für Zusammenführen (merge und push), Anmerkung zu fast forward merge]{.ex href="https://youtu.be/moqywsxtEy8"}
 
 
-## Branches und Remotes
+# Branches und Remotes
 
 *   Eigenen (neuen) lokalen Branch ins remote Repo schicken
     *   `git push <remote> <branch>`
@@ -294,7 +294,7 @@ werden).
 [[Beispiel]{.ex}]{.slides}
 
 
-## Zusammenfassung: Arbeiten mit Remotes
+# Zusammenfassung: Arbeiten mit Remotes
 
 1.  Änderungen vom Server holen: `git fetch <remote>` \newline
     => Holt alle Änderungen vom Repo `<remote>` ins eigene Repo
@@ -311,7 +311,7 @@ werden).
 
 
 ::::::::: notes
-### Anmerkung: _push_ geht nur, wenn
+## Anmerkung: _push_ geht nur, wenn
 
 1. Ziel ein "bare"-Repository ist, **und**
 2. keine Konflikte entstehen
@@ -327,7 +327,7 @@ Github anlegen, automatisch der Fall. Sie können aber auch lokal ein solches
 mitgeben: `git init --bare` ...
 
 
-### Beispiel
+## Beispiel
 
     git fetch origin           # alle Änderungen vom Server holen
     git checkout master        # auf lokalen Master umschalten
@@ -339,7 +339,7 @@ mitgeben: `git init --bare` ...
 :::::::::
 
 
-## Vereinfachung: Tracking Branches
+# Vereinfachung: Tracking Branches
 
 *   **Tracking Branch**: lokaler Branch, der remote Branch "verfolgt"
     *   Beispiel: lokaler `master`-Branch folgt `origin/master` per Default
@@ -357,7 +357,7 @@ mitgeben: `git init --bare` ...
 Vorsicht: `pull` und `push` beziehen sich nur auf ausgecheckten Tracking Branch
 
 
-## Einrichten von Tracking Branches
+# Einrichten von Tracking Branches
 
 *   `git clone`: lokaler `master` trackt automatisch `origin/master`
 
@@ -378,7 +378,7 @@ Vorsicht: `pull` und `push` beziehen sich nur auf ausgecheckten Tracking Branch
 [[Beispiel]{.ex}]{.slides}
 
 
-## Hinzufügen eines (weiteren) Remote Repository
+# Hinzufügen eines (weiteren) Remote Repository
 
 ![](images/screenshot_branches.png){width="75%"}
 
@@ -404,7 +404,7 @@ Beispiel: `git fetch andi` oder `git push origin master`
 [[Beispiel]{.ex}]{.slides}
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Synchronisierung des lokalen Repos mit anderen Repos
     *   Repo kopieren: `git clone <url>`

--- a/lecture/git/workflows.md
+++ b/lecture/git/workflows.md
@@ -49,7 +49,7 @@ attachments:
 ---
 
 
-## Nutzung von Git in Projekten: Verteiltes Git (und Workflows)
+# Nutzung von Git in Projekten: Verteiltes Git (und Workflows)
 
 ![](images/distributed.png){width="80%"}
 
@@ -68,7 +68,7 @@ Antwort: Workflows mit Git ...
 :::
 
 
-## Zusammenarbeit: Zentraler Workflow mit Git (analog zu SVN)
+# Zusammenarbeit: Zentraler Workflow mit Git (analog zu SVN)
 
 ![](images/centralised.png){width="80%"}
 
@@ -95,7 +95,7 @@ gleichberechtigt und direkt pushen dürfen.
 :::
 
 
-## Zusammenarbeit: Einfacher verteilter Workflow mit Git
+# Zusammenarbeit: Einfacher verteilter Workflow mit Git
 
 ![](images/workflow_remote.png){width="80%"}
 
@@ -148,7 +148,7 @@ und das geschützte ("blessed") Master-Repo als `upstream` referenziert.
 
 
 ::::::::: notes
-### Anmerkungen zum Forken
+## Anmerkungen zum Forken
 
 Sie könnten auch das Original-Repo direkt clonen. Allerdings würden dann die
 `push` dort aufschlagen, was in der Regel nicht erwünscht ist (und auch nicht
@@ -159,7 +159,7 @@ eine Kopie des Original-Repos im eigenen Namespace angelegt. Auf diese Kopie
 hat man dann uneingeschränkten Zugriff.
 
 
-### Anmerkungen zu den Namen für die Remotes: `origin` und `upstream`
+## Anmerkungen zu den Namen für die Remotes: `origin` und `upstream`
 
 Üblicherweise checkt man die *Kopie* lokal aus (d.h. erzeugt einen Clone).
 In der Workingcopy verweist dann `origin` auf die Kopie. Um Änderungen am
@@ -178,7 +178,7 @@ zu bringen, führt man dann einfach folgendes aus (im Beispiel für den `master`
 [[Beispiel: Forken mit Gitlab, Namen für Remotes]{.ex}]{.slides}
 
 
-## Feature-Branches aktualisieren: Mergen mit _master_ vs. Rebase auf _master_
+# Feature-Branches aktualisieren: Mergen mit _master_ vs. Rebase auf _master_
 
 ::: notes
 Im Netz finden sich häufig Anleitungen, wonach man Änderungen im `master`
@@ -216,7 +216,7 @@ dessen Rebase) rebasen ... vgl. auch "The Perils of Rebasing" in Abschnitt "3.6 
 [@Chacon2014].
 
 
-### Mögliches Szenario im Praktikum
+## Mögliches Szenario im Praktikum
 
 Im Praktikum haben Sie das Vorgabe-Repo. Dieses könnten Sie als `upstream` in Ihre lokale
 Workingcopy einbinden.
@@ -245,7 +245,7 @@ inkompatible Weise geändert hat ...
 [[Besser einen Pull/Rebase für den Feature-Branch machen!]{.ex}]{.slides}
 
 
-## Kommunikation: Merge- bzw. Pull-Requests
+# Kommunikation: Merge- bzw. Pull-Requests
 
 ::: notes
 Mergen kann man auf der Konsole (oder in der IDE) und anschließend die (neuen) Branches
@@ -278,7 +278,7 @@ Nachfolgend für den selben MR aus der letzten Abbildung noch die reine Diskussi
 
 
 ::::::::: notes
-## Best Practices bei Merge-/Pull-Requests
+# Best Practices bei Merge-/Pull-Requests
 
 1.  MR/PR so zeitig wie möglich aufmachen
     *   Am besten sofort, wenn ein neuer Branch auf den Server gepusht wird!
@@ -318,7 +318,7 @@ Nachfolgend für den selben MR aus der letzten Abbildung noch die reine Diskussi
 :::::::::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Git-Workflows für die Zusammenarbeit:
     *   einfacher zentraler Ansatz für kleine Arbeitsgruppen vs.

--- a/lecture/git/worktree.md
+++ b/lecture/git/worktree.md
@@ -25,9 +25,9 @@ fhmedia:
 ---
 
 
-## Git Worktree - Mehrere Branches parallel auschecken
+# Git Worktree - Mehrere Branches parallel auschecken
 
-### Szenario
+## Szenario
 
 *   Sie arbeiten an einem Projekt
 *   Großes Repo mit vielen Versionen und Branches
@@ -36,7 +36,7 @@ fhmedia:
 
 \bigskip
 
-### Lösungsansätze
+## Lösungsansätze
 
 *   `git stash` nutzen und Branch wechseln
 *   Repo erneut in anderem Ordner auschecken
@@ -44,7 +44,7 @@ fhmedia:
 \bigskip
 
 ::: notes
-### Probleme
+## Probleme
 
 1.  `git stash` und `git switch`
 
@@ -77,17 +77,17 @@ fhmedia:
 
 \bigskip
 
-### Git Worktree kann helfen!
+## Git Worktree kann helfen!
 
 **=> Mehrere Branches gleichzeitig auschecken (als neue Ordner im Dateisystem)**
 
 
-## How to use Git Worktree
+# How to use Git Worktree
 
 ![](images/linkedworktrees.png){width="80%"}
 
 
-## Worktree anlegen
+# Worktree anlegen
 
 ::: center
 `git worktree add <path> <branch>`
@@ -129,7 +129,7 @@ werden (unstabiles Verhalten)!
 :::
 
 
-## Worktree wechseln
+# Worktree wechseln
 
 *   Worktrees anzeigen: `git worktree list`
 *   Worktree wechseln: Ordner wechseln (IDE: neues Projekt)
@@ -153,7 +153,7 @@ zu vermeiden.
 :::
 
 
-## Worktree löschen
+# Worktree löschen
 
 ::: center
 `git worktree remove <worktree>`
@@ -167,7 +167,7 @@ Dabei bleibt der Ordner erhalten - Sie können ihn selbst löschen oder später 
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 Git Worktree: Auschecken von Branches in separate Ordner
 

--- a/lecture/gui/events.md
+++ b/lecture/gui/events.md
@@ -37,7 +37,7 @@ fhmedia:
 ---
 
 
-## Reaktion auf Events: Anwendung Observer-Pattern
+# Reaktion auf Events: Anwendung Observer-Pattern
 
 ::: notes
 *   Swing-GUI läuft in Dauerschleife
@@ -65,7 +65,7 @@ component.addMouseListener(MouseListener);
 ```
 
 
-## Arten von Events
+# Arten von Events
 
 ![](images/EventListener.png){width="80%"}
 
@@ -76,7 +76,7 @@ bekommt und viele weitere.
 :::
 
 
-## Details zu Listenern
+# Details zu Listenern
 
 *   Ein Listener kann bei mehreren Observables registriert sein:
 
@@ -98,7 +98,7 @@ bekommt und viele weitere.
 [Demo: events.ListenerDemo]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/events/ListenerDemo.java"}
 
 
-## Wie komme ich an die Daten eines Events?
+# Wie komme ich an die Daten eines Events?
 
 ![](images/EventObject.png){width="80%"}
 
@@ -107,7 +107,7 @@ bekommt und viele weitere.
 [Demo: events.MouseListenerDemo]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/events/MouseListenerDemo.java"}
 
 
-## Listener vs. Adapter
+# Listener vs. Adapter
 
 ::: notes
 *   Vielzahl möglicher Events
@@ -133,7 +133,7 @@ Abhilfe: **Adapter**-Klassen:
 [Demo: events.MouseAdapterDemo]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/events/MouseAdapterDemo.java"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 Observer-Pattern in Swing-Komponenten:
 

--- a/lecture/gui/java2d.md
+++ b/lecture/gui/java2d.md
@@ -50,14 +50,14 @@ fhmedia:
 ---
 
 
-## GUIs mit Java
+# GUIs mit Java
 
 ![](images/java2d.png){width="40%"}
 
 [Demo: java2d.simplegame.J2DTeaser]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/java2d/simplegame/J2DTeaser.java"}
 
 
-## Einführung in die Java 2D API
+# Einführung in die Java 2D API
 
 ::: notes
 *   Bisher: Anordnung von Widgets als GUI
@@ -104,7 +104,7 @@ Objekt vom Typ `Graphics` stellt graphischen Kontext dar
 :::
 
 
-## Java2D Koordinatensystem
+# Java2D Koordinatensystem
 
 ![](images/java2d-koordinaten.png){width="60%"}
 
@@ -114,7 +114,7 @@ Objekt vom Typ `Graphics` stellt graphischen Kontext dar
 *   Einheiten in Pixel(!)
 
 
-## Einfache Objekte zeichnen
+# Einfache Objekte zeichnen
 
 Methoden von `java.awt.Graphics` (Auswahl):
 
@@ -140,7 +140,7 @@ Vorher Strichfarbe setzen: `Graphics.setColor(Color color)`:
 [Demo: java2d.SimpleDrawings]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/java2d/SimpleDrawings.java"}
 
 
-## Fonts und Strings
+# Fonts und Strings
 
 Fonts über Font-Klasse einstellen: `Graphics.setFont(Font font);`
 
@@ -161,7 +161,7 @@ Vorher Font und Farbe setzen!
 [Demo: java2d.SimpleFonts]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/java2d/SimpleFonts.java"}
 
 
-## Einfache Polygone definieren
+# Einfache Polygone definieren
 
 Polygone zeichnen: `Graphics.drawPolygon(Polygon p)`:
 
@@ -200,7 +200,7 @@ Vorher Farbe setzen!
 [Demo: java2d.SimplePoly]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/java2d/SimplePoly.java"}
 
 
-## Ausblick I: Umgang mit Bildern
+# Ausblick I: Umgang mit Bildern
 
 ```java
 BufferedImage img = ImageIO.read(new File("DukeWave.gif"));
@@ -209,7 +209,7 @@ boolean Graphics.drawImage(Image img, int x, int y, ImageObserver observer);
 ```
 
 
-## Ausblick II: _Graphics2D_ kann noch mehr ...
+# Ausblick II: _Graphics2D_ kann noch mehr ...
 
 ```java
 Graphics g;
@@ -229,7 +229,7 @@ Graphics2D g2 = (Graphics2D) g;
 *   ...
 
 
-## Spiele mit Bewegung
+# Spiele mit Bewegung
 
 Beobachtung: `paintComponent()` schreibt `Graphics`-Objekt komplett neu!
 
@@ -269,7 +269,7 @@ Idee: Je Zeitschritt:
 [[Hinweis: Zentrale Struktur vs. Observer-Pattern]{.ex}]{.slides}
 
 
-## Erinnerung: Observer Pattern
+# Erinnerung: Observer Pattern
 
 ![](images/observer.png){width="80%"}
 
@@ -287,7 +287,7 @@ Idee: Je Zeitschritt:
 :::
 
 
-## Spielobjekte als Observer (Listener)
+# Spielobjekte als Observer (Listener)
 
 ::: notes
 Objekte können sich auf `Graphics` darstellen:
@@ -317,7 +317,7 @@ Weitere evtl. nützliche Methoden:
 *   Methode zum Umdrehen der Bewegungsrichtung
 
 
-## Oberfläche zusammenbauen
+# Oberfläche zusammenbauen
 
 1.  Spielfeld von `JPanel` ableiten: Observable
 2.  Observer registrieren: Liste mit Spiel-Objekten anlegen
@@ -361,7 +361,7 @@ Weitere evtl. nützliche Methoden:
 [Demo: java2d.simplegame.J2DTeaser]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/java2d/simplegame/J2DTeaser.java"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Java2D: Swing-Komponenten zeichnen mit `paintComponent()` auf `Graphics`
 *   `Graphics`: Methoden zum Zeichnen von Linien, Rechtecken, Ovalen, Text ...

--- a/lecture/gui/layouts.md
+++ b/lecture/gui/layouts.md
@@ -78,7 +78,7 @@ challenges: |
 ---
 
 
-## Überblick
+# Überblick
 
 Anordnung der Komponenten [in einem Container ist]{.notes} abhängig vom **Layout**
 
@@ -93,7 +93,7 @@ Verschiedene beliebte Layout-Manager:
 *   ...
 
 
-## _BorderLayout_
+# _BorderLayout_
 
 ![](images/screenshot-borderlayout.png){width="40%"}
 
@@ -129,7 +129,7 @@ werden (horizontal und vertikal, Abstände in Pixel).
 [Demo: layout.Border]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/layout/Border.java"}
 
 
-## _FlowLayout_
+# _FlowLayout_
 
 ![](images/screenshot-flowlayout.png){width="60%"}
 
@@ -157,7 +157,7 @@ werden, ebenso wie ein vertikales und horizontales Padding zwischen den Komponen
 [Demo: layout.Flow]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/layout/Flow.java"}
 
 
-## _GridLayout_
+# _GridLayout_
 
 ![](images/screenshot-gridlayout.png){width="40%"}
 
@@ -187,7 +187,7 @@ werden.
 [Demo: layout.Grid]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/layout/Grid.java"}
 
 
-## Komplexer Layout-Manager: _GridBagLayout_
+# Komplexer Layout-Manager: _GridBagLayout_
 
 *   Layout-Manager ähnlich zu `GridLayout`
 *   Zusätzlich `GridBagConstraints`: Verhalten bei Größenveränderungen
@@ -239,7 +239,7 @@ aufgeteilt.
 [Demo: layout.GridBag]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/layout/GridBag.java"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Anordnung von Komponenten lässt sich mit Layout-Manager steuern
 

--- a/lecture/gui/swing-basics.md
+++ b/lecture/gui/swing-basics.md
@@ -39,7 +39,7 @@ fhmedia:
 ---
 
 
-## Wiederholung GUI in Java
+# Wiederholung GUI in Java
 
 *   **AWT**: `abstract window toolkit`
     *   Älteres Framework ("Legacy")
@@ -69,7 +69,7 @@ Präfix "J": `java.awt.Button` (AWT) => `javax.swing.JButton` (Swing)
 :::
 
 
-## Graphische Komponenten einer GUI
+# Graphische Komponenten einer GUI
 
 *   Top-Level Komponenten
     *   Darstellung direkt auf Benutzeroberfläche des Betriebssystems
@@ -92,7 +92,7 @@ Klasse `javax.swing.JComponent` ab!
 => Nutzung "falscher" Methoden führt zu Laufzeitfehlern.
 
 
-## Ein einfaches Fenster
+# Ein einfaches Fenster
 
 ```java
 public class FirstWindow {
@@ -108,7 +108,7 @@ public class FirstWindow {
 ```
 
 ::: notes
-### Elemente
+## Elemente
 
 Es wird ein neuer Frame angelegt als Top-Level-Komponente. Der Fenstertitel wird auf "Hello World :)"
 gesetzt.
@@ -120,7 +120,7 @@ Mit der Swing-Methode `pack()` werden alle Komponenten berechnet und die Fenster
 alle Komponenten Platz haben. Bis dahin ist das Fenster aber unsichtbar und wird erst über den Aufruf
 von `setVisible(true)` auch dargestellt.
 
-### Swing und Multithreading: Event Dispatch Thread
+## Swing und Multithreading: Event Dispatch Thread
 
 Leider ist die Welt nicht ganz so einfach. In Swing werden Events wie das Drücken eines Buttons
 durch den _Event Dispatch Thread_ (EDT) abgearbeitet. (Zum Thema Events in Swing siehe Einheit
@@ -162,7 +162,7 @@ Siehe auch ["Concurrency in Swing"](https://docs.oracle.com/javase/tutorial/uisw
 [Demo: basics.SecondWindow]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/basics/SecondWindow.java"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Swing baut auf AWT auf und nutzt dieses
 *   JavaFX ist moderner, aber kein Swing-Ersatz geworden

--- a/lecture/gui/tables.md
+++ b/lecture/gui/tables.md
@@ -32,7 +32,7 @@ fhmedia:
 ---
 
 
-## Einfache Tabelle mit festen Daten
+# Einfache Tabelle mit festen Daten
 
 *   Einfache Tabelle erzeugen:
 
@@ -71,7 +71,7 @@ contentPane.add(table, BorderLayout.CENTER);
 [Demo: tables.SimpleTable]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/tables/SimpleTable.java"}
 
 
-## Selektierbare und sortierbare Tabelle
+# Selektierbare und sortierbare Tabelle
 
 *   Tabelle sortierbar machen:
 
@@ -104,7 +104,7 @@ contentPane.add(table, BorderLayout.CENTER);
 [Demo: tables.SelectTable]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/tables/SelectTable.java"}
 
 
-## Einschub: MVC-Pattern
+# Einschub: MVC-Pattern
 
 ![](images/mvc.png){width="60%"}
 
@@ -128,7 +128,7 @@ Dieses Pattern findet sich mittlerweile in diversen (leichten) Variationen.
 :::
 
 
-## Daten in separatem Modell
+# Daten in separatem Modell
 
 *   Modell muss von `AbstractTableModel` ableiten
 *   Methoden zur Interaktion mit Tabelle implementieren!
@@ -149,7 +149,7 @@ Dieses Pattern findet sich mittlerweile in diversen (leichten) Variationen.
 => Kapselung der Daten! Müssen nicht als Array o.ä. vorliegen!
 
 
-## Modelleigenschaften
+# Modelleigenschaften
 
 *   Korrekte Spalten-Typen und damit bessere Anzeige:
 
@@ -174,7 +174,7 @@ Dieses Pattern findet sich mittlerweile in diversen (leichten) Variationen.
 
 
 ::: notes
-## Eigene Listener beim Modell registrieren
+# Eigene Listener beim Modell registrieren
 
 ```java
 TableModel m = table.getModel();
@@ -199,7 +199,7 @@ Zusätzlich kann man beim Modell eigene Listener registrieren, die auf Events du
 [Demo: tables.ModelTable]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/tables/ModelTable.java"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Fortgeschrittene Swing-Komponenten
     *   Komplexe Daten mit `JTable` anzeigen

--- a/lecture/gui/widgets.md
+++ b/lecture/gui/widgets.md
@@ -46,7 +46,7 @@ fhmedia:
 ---
 
 
-## Radiobuttons: _JRadioButton_
+# Radiobuttons: _JRadioButton_
 
 \bigskip
 
@@ -81,7 +81,7 @@ fhmedia:
 [Demo: widgets.RadioButtonDemo]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/widgets/RadioButtonDemo.java"}
 
 
-## Dateien oder Verzeichnisse auswählen: _JFileChooser_
+# Dateien oder Verzeichnisse auswählen: _JFileChooser_
 
 ![](images/screenshot-filechooser.png){width="40%"}
 
@@ -112,7 +112,7 @@ if (fc.showOpenDialog() == JFileChooser.APPROVE_OPTION)
 [Demo: widgets.FileChooserDemo]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/widgets/FileChooserDemo.java"}
 
 
-## TabbedPane und Scroll-Bars
+# TabbedPane und Scroll-Bars
 
 \bigskip
 
@@ -152,7 +152,7 @@ if (fc.showOpenDialog() == JFileChooser.APPROVE_OPTION)
 [Demo: widgets.TabbedPaneDemo]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/widgets/TabbedPaneDemo.java"}
 
 
-## Dialoge mit _JOptionPane_
+# Dialoge mit _JOptionPane_
 
 ![](images/screenshot-dialog.png){width="40%"}
 
@@ -180,7 +180,7 @@ Fokus, wenn der Dialog geschlossen wurde.
 [Demo: widgets.DialogDemo]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/widgets/DialogDemo.java"}
 
 
-## Menüs mit _JMenuBar_, _JMenu_ und _JMenuItem_
+# Menüs mit _JMenuBar_, _JMenu_ und _JMenuItem_
 
 ```java
 JMenuBar menuBar = new JMenuBar();
@@ -210,7 +210,7 @@ sind vom Typ `JMenuItem` und verhalten sich wie Buttons.
 [Demo: widgets.MenuDemo]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/widgets/MenuDemo.java"}
 
 
-## Kontextmenü mit _JPopupMenu_
+# Kontextmenü mit _JPopupMenu_
 
 *   Menü kann über anderen Komponenten angezeigt werden
 
@@ -227,13 +227,13 @@ sind vom Typ `JMenuItem` und verhalten sich wie Buttons.
     ```
 
 ::: notes
-### Details zu _JMenuItem_
+## Details zu _JMenuItem_
 
 *   Erweitert `AbstractButton`
 *   Reagiert auf `ActionEvent`
     => `ActionListener` implementieren für Reaktion auf Menüauswahl
 
-### Details zum Kontextmenü
+## Details zum Kontextmenü
 
 **Triggern der Anzeige eines `JPopupMenu`**
 
@@ -258,7 +258,7 @@ myFrame.addMouseListener(new MouseAdapter() {
 [Demo: widgets.PopupDemo]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/gui/src/widgets/PopupDemo.java"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 Nützliche Swing-Komponenten:
 

--- a/lecture/java-classic/annotations.md
+++ b/lecture/java-classic/annotations.md
@@ -59,7 +59,7 @@ challenges: |
 ---
 
 
-## Was passiert hier?
+# Was passiert hier?
 
 ```java
 public class A {
@@ -98,7 +98,7 @@ generieren: `Preferences > Java > Code Style > Add @Override annotation ...`.
 :::
 
 
-## Annotationen: Metadaten für Dritte
+# Annotationen: Metadaten für Dritte
 
 *   **Zusatzinformationen** für Tools, Bibliotheken, ...
 *   Kein direkter Einfluss auf die Ausführung des annotierten Codes
@@ -125,14 +125,14 @@ Anschließend lernen Sie die Dokumentation mittels Javadoc-Annotationen kennen.
 Das Thema JUnit ist in einer anderen VL dran. Webservices ereilen Sie dann in
 späteren Semestern :-)
 
-### \@Override
+## \@Override
 
 Die mit `@Override` annotierte Methode überschreibt eine Methode aus der Oberklasse oder implementiert eine
 Methode einer Schnittstelle. Dies wird durch den Compiler geprüft und ggf. mit einer Fehlermeldung quittiert.
 
 `@Override` ist eine im JDK im Paket `java.lang` enthaltene Annotation.
 
-### \@Deprecated
+## \@Deprecated
 
 Das mit `@Deprecated` markierte Element ist veraltet ("*deprecated*") und sollte nicht mehr benutzt werden.
 Typischerweise werden so markierte Elemente in zukünftigen Releases aus der API entfernt ...
@@ -142,7 +142,7 @@ im Javadoc. Allerdings kann letzteres nur von Javadoc ausgewertet werden.
 
 `@Deprecated` ist eine im JDK im Paket `java.lang` enthaltene Annotation.
 
-### Weitere Annotationen aus _java.lang_
+## Weitere Annotationen aus _java.lang_
 
 Im Paket `java.lang` finden sich weitere Annotationen. Mit Hilfe von `@SuppressWarnings` lassen sich bestimmte
 Compilerwarnungen unterdrücken (**so etwas sollte man NIE tun!**), und mit `@FunctionalInterface`
@@ -152,7 +152,7 @@ Weitere Annotationen aus dem JDK finden sich in den Paketen `java.lang.annotatio
 :::::::::
 
 
-## Dokumentation mit Javadoc
+# Dokumentation mit Javadoc
 
 ```java
 /**
@@ -179,7 +179,7 @@ Hier noch einmal exemplarisch die wichtigsten Elemente, die an
 [[Beispiel: annotations.B (Javadoc)]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/annotations/B.java"}]{.notes}
 
 
-## \@NotNull mit IntelliJ
+# \@NotNull mit IntelliJ
 
 ::: notes
 [IntelliJ](https://www.jetbrains.com/help/idea/annotating-source-code.html) bietet im Paket
@@ -226,17 +226,17 @@ public void foo(@NotNull Object o) {
 [Demo: annotations.WuppieAnnotation: \@NotNull]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/annotations/WuppieAnnotation.java"}
 
 ::: notes
-### IntelliJ inferiert mit \@NotNull mögliche _null_-Werte
+## IntelliJ inferiert mit \@NotNull mögliche _null_-Werte
 
 ![](images/screenshot_infer-notnull.png){width="80%"}
 
-### IntelliJ baut bei \@NotNull passende Assertions ein
+## IntelliJ baut bei \@NotNull passende Assertions ein
 
 ![](images/screenshot_nullpointerexception-notnull.png){width="80%"}
 :::
 
 
-## Eigene Annotationen erstellen
+# Eigene Annotationen erstellen
 
 ```java
 public @interface MyFirstAnnotation {}
@@ -255,11 +255,11 @@ public class C {}
 [Demo: annotations.C]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/annotations/C.java"}
 
 ::::::::: notes
-### Definition einer Annotation
+## Definition einer Annotation
 
 Definition einer Annotation wie Interface, aber mit "`@`"-Zeichen vor dem `interface`-Schlüsselwort
 
-### Parameter für Annotation
+## Parameter für Annotation
 
 Parameter für Annotation werden über entsprechende Methoden-Deklaration realisiert
 
@@ -287,7 +287,7 @@ Parameter für Annotation werden über entsprechende Methoden-Deklaration realis
 *   Defaultwerte mit dem nachgestellten Schlüsselwort `default` sowie dem
     Defaultwert selbst
 
-### Javadoc
+## Javadoc
 
 Soll die Annotation in der Javadoc-Doku dargestellt werden, muss sie mit
 der Meta-Annotation `@Documented` ausgezeichnet werden (aus
@@ -296,7 +296,7 @@ der Meta-Annotation `@Documented` ausgezeichnet werden (aus
 *Hinweis*: Die Annotation wird lediglich in die Doku aufgenommen, d.h. es
 erfolgt keine weitere Verarbeitung oder Hervorhebung o.ä.
 
-### Wann ist eine Annotation sichtbar (Beschränkung der Sichtbarkeit)
+## Wann ist eine Annotation sichtbar (Beschränkung der Sichtbarkeit)
 
 Annotationen werden vom Compiler und/oder anderen Tools ausgewertet. Man
 kann entsprechend die Sichtbarkeit einer Annotation beschränken: Sie kann
@@ -320,9 +320,9 @@ Beschränkung der Sichtbarkeit: Meta-Annotation `@Retention` aus
 Ohne explizite Angabe gilt für die selbst definierte Annotation die
 Einstellung `RetentionPolicy.CLASS`.
 
-### Wo darf eine Annotation verwendet werden
+## Wo darf eine Annotation verwendet werden
 
-#### Anwendungsmöglichkeiten von Annotationen im Code
+### Anwendungsmöglichkeiten von Annotationen im Code
 
 ```java
 @ClassAnnotation
@@ -343,7 +343,7 @@ public class Wuppie {
 }
 ```
 
-#### Einschränkung des Einsatzes eines Annotation
+### Einschränkung des Einsatzes eines Annotation
 
 Für jede Annotation kann eingeschränkt werden, wo (an welchen Java-Elementen)
 sie verwendet werden darf.
@@ -363,7 +363,7 @@ Elemente verwendbar.
 :::::::::
 
 
-## Annotationen [bei Compilieren]{ .notes} bearbeiten: Java Annotation-Prozessoren
+# Annotationen [bei Compilieren]{ .notes} bearbeiten: Java Annotation-Prozessoren
 
 ::: notes
 Der dem `javac`-Compiler vorgelegte Source-Code wird eingelesen und in einen
@@ -467,7 +467,7 @@ Note: found @MySecondAnnotation at main(java.lang.String[])
 :::::::::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Annotationen: Metadaten zum Programm
 

--- a/lecture/java-classic/collections.md
+++ b/lecture/java-classic/collections.md
@@ -34,7 +34,7 @@ fhmedia:
 ---
 
 
-## Motivation: Snippet aus einer Klasse im PM-Dungeon
+# Motivation: Snippet aus einer Klasse im PM-Dungeon
 
 ```java
 private List<Entity> entities = new ArrayList<>();
@@ -58,7 +58,7 @@ Objekt nur _einmal_ enthalten.
 :::
 
 
-## Collection-API in Java
+# Collection-API in Java
 
 ![](images/collection.png){width="72%"}
 
@@ -103,7 +103,7 @@ Siehe auch [Interface Collection](https://docs.oracle.com/en/java/javase/17/docs
 :::
 
 
-## Listen: _ArrayList_
+# Listen: _ArrayList_
 
 ```java
 private List<Entity> entities = new ArrayList<>();
@@ -139,7 +139,7 @@ Die Methoden einer `ArrayList<T>` sind nicht `synchronized`.
 :::
 
 
-## Listen: _LinkedList_
+# Listen: _LinkedList_
 
 ![](images/linkedlist.png){width="80%"}
 
@@ -169,7 +169,7 @@ Die Methoden einer `LinkedList<T>` sind nicht `synchronized`.
 :::
 
 
-## _Vector_ und _Stack_
+# _Vector_ und _Stack_
 
 *   `Vector<T>`:
     *   Ein `Vector<T>` ähnelt einer `ArrayList<T>`
@@ -185,7 +185,7 @@ Die Methoden einer `LinkedList<T>` sind nicht `synchronized`.
     *   Tatsächlich aber: `class Stack<E> extends Vector<E>`
 
 
-## Iterierbarkeit: _Iterable_ und _Iterator_
+# Iterierbarkeit: _Iterable_ und _Iterator_
 
 ```java
 private List <Entity> entities = new ArrayList<>();
@@ -227,7 +227,7 @@ genutzt werden kann, muss sie aber auch noch `Iterable<T>` implementieren.
 :::
 
 
-## Hilfsklasse _Collections_
+# Hilfsklasse _Collections_
 
 ![](images/collections.png){width="70%" web_width="50%"}
 
@@ -245,7 +245,7 @@ vermutlich die statischen Methoden in der Klasse `Collections` eher direkt als D
 :::
 
 
-## _Map_
+# _Map_
 
 ![](images/map.png){width="55%" web_width="50%"}
 
@@ -278,7 +278,7 @@ Siehe auch [Interface Map](https://docs.oracle.com/en/java/javase/17/docs/api/ja
 :::
 
 
-## _HashMap_
+# _HashMap_
 
 ![](images/hashmap.png){width="72%" web_width="60%"}
 
@@ -313,7 +313,7 @@ eine doppelt verkettete Liste verwendet.
 :::
 
 
-## _Hashtable_
+# _Hashtable_
 
 *   Nicht zu verwechseln mit der Datenstruktur: Hash-Tabellen (!)
 *   `Hashtable<K,V>` ist vergleichbar mit einer `HashMap<K,V>`
@@ -322,9 +322,9 @@ eine doppelt verkettete Liste verwendet.
 
 
 ::::::::: notes
-## Spielregeln für _equals()_, _hashCode()_ und _compareTo()_
+# Spielregeln für _equals()_, _hashCode()_ und _compareTo()_
 
-### _equals()_
+## _equals()_
 
 `boolean equals(Object o)` ist eine Methode Klasse `Object` und wird genutzt, um Objekte auf Gleichheit zu
 prüfen. Die Default-Implementierung von `equals()` in `Object` vergleicht die beiden Objekte mit `==`, gibt
@@ -341,7 +341,7 @@ Dabei sind Spielregeln zu beachten (für nicht-`null` Objekte `x`, `y` und `z`):
 4.  Konsistenz: Mehrfache Aufrufe von `equals()` mit den selben Werten müssen immer das selbe Ergebnis liefern
 5.  `x.equals(null) == false`
 
-### _hashCode()_
+## _hashCode()_
 
 Die Methode `int hashCode()` gibt den Hash-Wert eines Objektes zurück. Der Hash-Wert eins Objektes wird genutzt,
 um dieses in einen Hash-basierten Container abzulegen bzw. zu finden.
@@ -349,7 +349,7 @@ um dieses in einen Hash-basierten Container abzulegen bzw. zu finden.
 Der Rückgabewert der Methode `hashCode()` für ein Objekt bleibt über die Laufzeit einer Anwendung immer identisch,
 solange sich die zur Prüfung der Gleichheit genutzten Attribute nicht ändern.
 
-### _compareTo()_
+## _compareTo()_
 
 Die Methode `int compareTo()` (Interface `Comparable<T>`) vergleicht Objekte und definiert damit eine Ordnung
 auf den Objekten. Während `equals()` für die Prüfung auf Gleichheit eingesetzt wird, wird `compareTo()` für die
@@ -364,11 +364,11 @@ Spielregeln:
 4.  Transitivität: Wenn `x.compareTo(y) > 0` und `y.compareTo(z) > 0`, dann auch `x.compareTo(z) > 0`
 5.  Wenn `x.compareTo(y) == 0`, dann auch `signum(x.compareTo(z)) == signum(y.compareTo(z))`
 
-### Der _equals()_-_hashCode()_-_compareTo()_-Vertrag
+## Der _equals()_-_hashCode()_-_compareTo()_-Vertrag
 :::::::::
 
 ::: slides
-## Der _equals()_-_hashCode()_-_compareTo()_-Vertrag
+# Der _equals()_-_hashCode()_-_compareTo()_-Vertrag
 :::
 
 **Wird `equals()` überschrieben, sollte auch `hashCode()` (passend) überschrieben werden.**
@@ -394,7 +394,7 @@ Spielregeln:
 
 
 ::: notes
-## Überblick
+# Überblick
 
 ![](images/collections_table.png){width="80%"}
 
@@ -403,7 +403,7 @@ Komplexitätswerte beziehen sich auf den Regelfall. Sonderfälle wie das Vergrö
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Interface `Collection<T>`: Schnittstelle für Datenstrukturen/Sammlungen
     [zur Verwaltung einer Menge von Objekten]{.notes}

--- a/lecture/java-classic/configuration.md
+++ b/lecture/java-classic/configuration.md
@@ -41,7 +41,7 @@ fhmedia:
 ---
 
 
-## Wie kann man Programme konfigurieren?
+# Wie kann man Programme konfigurieren?
 
 1.  Parameter beim Start mitgeben: Kommandozeilenparameter (CLI)
 
@@ -50,7 +50,7 @@ fhmedia:
 2.  Konfigurationsdatei einlesen und auswerten
 
 
-## Varianten von Kommandozeilenparameter
+# Varianten von Kommandozeilenparameter
 
 *   Fixe Reihenfolge
 
@@ -95,7 +95,7 @@ Hinweis IntelliJ: "`Edit Configurations`" => Kommandozeilenparameter unter "`Bui
 :::
 
 
-## Auswertung Kommandozeilenparameter
+# Auswertung Kommandozeilenparameter
 
 *   Kommandozeilenparameter [werden]{.notes}  als String-Array  [an `main()`-Methode übergeben:]{.notes}
 
@@ -113,7 +113,7 @@ Hinweis IntelliJ: "`Edit Configurations`" => Kommandozeilenparameter unter "`Bui
 _Anmerkung_: Nur Parameter! Nicht Programmname als erster Eintrag wie in C ...
 
 
-## Beispiel Auswertung Kommandozeilenparameter
+# Beispiel Auswertung Kommandozeilenparameter
 
 ```java
 public static void main(String[] args) {
@@ -132,7 +132,7 @@ public static void main(String[] args) {
 ```
 
 ::: notes
-### Kritik an manueller Auswertung Kommandozeilenparameter
+## Kritik an manueller Auswertung Kommandozeilenparameter
 
 *   Umständlich und unübersichtlich
 *   Große `if-else`-Gebilde in `main()`
@@ -144,7 +144,7 @@ public static void main(String[] args) {
 :::
 
 
-## Apache Commons: CLI
+# Apache Commons: CLI
 
 **Rad nicht neu erfinden!**
 
@@ -164,10 +164,10 @@ Annäherung an fremde API:
 *   Einbinden ins Projekt
 
 
-## Exkurs: Einbinden fremder Bibliotheken/APIs
+# Exkurs: Einbinden fremder Bibliotheken/APIs
 
 ::: notes
-### Eclipse
+## Eclipse
 
 *   Lib von [commons.apache.org](https://commons.apache.org/proper/commons-cli/download_cli.cgi)
     herunterladen und auspacken
@@ -176,7 +176,7 @@ Annäherung an fremde API:
 *   Projektexplorer, Kontextmenü auf `.jar`-File: "`Add as Library`"
 *   Alternativ Menü-Leiste: "`Project > Properties > Java Build Path > Libraries > Add JARs`"
 
-### IntelliJ
+## IntelliJ
 
 *   Variante 1:
     *   Lib von [commons.apache.org](https://commons.apache.org/proper/commons-cli/download_cli.cgi)
@@ -189,13 +189,13 @@ Annäherung an fremde API:
     *   Projekteigenschaften, Eintrag "Libraries", "+", "New Project Library", "From Maven" und
         "commons-cli:commons-cli:1.5.0" als Suchstring eingeben und die Suche abschließen
 
-### Gradle oder Ant oder Maven
+## Gradle oder Ant oder Maven
 
 *   Lib auf [Maven Central](https://search.maven.org/) suchen: "commons-cli:commons-cli" als Suchstring eingeben
 *   Passenden Dependency-Eintrag in das Build-Skript kopieren
 :::
 
-### Kommandozeilenaufruf
+## Kommandozeilenaufruf
 
 *   Class-Path bei Aufruf setzen:
     *   Unix: `java -cp .:<jarfile>:<jarfile> <mainclass>`
@@ -222,7 +222,7 @@ Dies funktioniert auch bei rekursiven Abhängigkeiten ...
 :::
 
 
-## Überblick Umgang mit Apache Commons CLI
+# Überblick Umgang mit Apache Commons CLI
 
 **Paket**: `org.apache.commons.cli`
 
@@ -243,7 +243,7 @@ zusätzlich in die Dokumentation.
 [Demo: Einbinden von Libs, cli.Args]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/cli/Args.java"}
 
 
-## Laden und Speichern von Konfigurationsdaten
+# Laden und Speichern von Konfigurationsdaten
 
 ```
 #ola - ein Kommentar
@@ -267,7 +267,7 @@ gewicht=12
     :::
 
 
-## Laden und Speichern von Konfigurationsdaten (cnt.)
+# Laden und Speichern von Konfigurationsdaten (cnt.)
 
 \bigskip
 
@@ -312,7 +312,7 @@ aber externe Bibliotheken, beispielsweise "Apache Commons Configuration"
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Kommandozeilenparameter als `String[]` in `main()`-Methode
 *   Manuelle Auswertung komplex => _Apache Commons CLI_

--- a/lecture/java-classic/enums.md
+++ b/lecture/java-classic/enums.md
@@ -41,7 +41,7 @@ challenges: |
 ---
 
 
-## Motivation
+# Motivation
 
 ```java
 public class Studi {
@@ -73,7 +73,7 @@ public class Studi {
 [[Beispiel enums.v1.Studi]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/enums/v1/Studi.java"}]{.notes}
 
 
-## Verbesserung: Einfache Aufzählung
+# Verbesserung: Einfache Aufzählung
 
 ```java
 public enum Fach {
@@ -94,7 +94,7 @@ public class Studi {
 ```
 
 
-## Einfache Aufzählungen: Eigenschaften
+# Einfache Aufzählungen: Eigenschaften
 
 ```java
 public enum Fach {
@@ -113,7 +113,7 @@ public enum Fach {
 
 
 ::::::::: notes
-### Wiederholung _static_
+## Wiederholung _static_
 
 **Attribute**:
 
@@ -132,7 +132,7 @@ public enum Fach {
 *   **Achtung**: In Klassenmethoden nur Klassenattribute nutzbar (keine Instanzattribute!),
     d.h. keine `this`-Referenz nutzbar
 
-### Wiederholung _final_: Attribute/Methoden/Klassen nicht änderbar
+## Wiederholung _final_: Attribute/Methoden/Klassen nicht änderbar
 
 *   Attribute: `final` Attribute können nur einmal gesetzt werden
 
@@ -155,7 +155,7 @@ public enum Fach {
 :::::::::
 
 
-## Einfache Aufzählungen: Eigenschaften (cnt.)
+# Einfache Aufzählungen: Eigenschaften (cnt.)
 
 ```java
 // Referenzen auf Enum-Objekte können null sein
@@ -188,7 +188,7 @@ Außerdem können wir folgende Eigenschaften nutzen (u.a., s.u.):
 [Demo: enums.v2.Studi]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/enums/v2/Studi.java"}
 
 
-## Enum: Genauer betrachtet
+# Enum: Genauer betrachtet
 
 ```java
 public enum Fach {  IFM, ELM, ARC  }
@@ -211,7 +211,7 @@ public class Fach extends Enum {
 => **Singleton-Pattern** für Konstanten
 
 
-## Enum-Klassen: Eigenschaften
+# Enum-Klassen: Eigenschaften
 
 ``` java
 public enum Fach {
@@ -237,12 +237,12 @@ public enum Fach {
 ```
 
 ::: notes
-### Konstruktoren und Methoden für Enum-Klassen definierbar
+## Konstruktoren und Methoden für Enum-Klassen definierbar
 
 *   Kein eigener Aufruf von `super` (!)
 *   Konstruktoren implizit `private`
 
-### Compiler fügt automatisch folgende Methoden hinzu (Auswahl):
+## Compiler fügt automatisch folgende Methoden hinzu (Auswahl):
 
 *   Strings:
     *   `public final String name()` => Name der Konstanten (`final`!)
@@ -260,7 +260,7 @@ public enum Fach {
 [Demo: enums.v3]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/tree/master/lecture/java-classic/src/enums/v3/"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Aufzählungen mit Hilfe von `enum` [(Compiler erzeugt intern Klassen)]{.notes}
 

--- a/lecture/java-classic/exceptions.md
+++ b/lecture/java-classic/exceptions.md
@@ -102,7 +102,7 @@ challenges: |
 ---
 
 
-## Fehlerfälle in Java
+# Fehlerfälle in Java
 
 ```java
 int div(int a, int b) {
@@ -118,7 +118,7 @@ div(3, 0);
 :::
 
 
-## Lösung?
+# Lösung?
 
 ```java
 Optional<Integer> div(int a, int b) {
@@ -146,7 +146,7 @@ if (x.isPresent()) {
 :::
 
 
-## Vererbungsstruktur _Throwable_
+# Vererbungsstruktur _Throwable_
 
 ![](images/exception.png){web_width="80%"}
 
@@ -154,7 +154,7 @@ if (x.isPresent()) {
 
 
 ::::::::: notes
-### _Exception_ vs. _Error_
+## _Exception_ vs. _Error_
 
 *   `Error`:
     *  Wird für Systemfehler verwendet (Betriebssystem, JVM, ...)
@@ -168,7 +168,7 @@ if (x.isPresent()) {
     *   Können "checked" oder "unchecked" sein
     *   Von Exceptions kann man sich erholen
 
-### Unchecked vs. Checked Exceptions
+## Unchecked vs. Checked Exceptions
 
 *   "Checked" Exceptions:
     *   Für erwartbare Fehlerfälle, deren Ursprung nicht im Programm selbst liegt
@@ -206,7 +206,7 @@ Beispiele unchecked Exception:
 :::::::::
 
 
-## _Throws_
+# _Throws_
 
 ```java
 int div(int a, int b) throws ArithmeticException {
@@ -262,7 +262,7 @@ damit umgehen (fangen oder selbst auch deklarieren). **Dies wird vom Compiler ge
 [[Hinweis: throws und checked vs. unchecked]{.ex}]{.slides}
 
 
-## _Try_-_Catch_
+# _Try_-_Catch_
 
 ```java
 int a = getUserInput();
@@ -288,7 +288,7 @@ geeignet zu melden!
 :::
 
 
-## _Try_und mehrstufiges _Catch_
+# _Try_und mehrstufiges _Catch_
 
 ```java
 try {
@@ -319,7 +319,7 @@ Exception handelt, müsste man diese per `throws IOException` an der Methode dek
 [[Hinweis: catch und Vererbungshierarchie]{.ex}]{.slides}
 
 
-## _Finally_
+# _Finally_
 
 ```java
 Scanner myScanner = new Scanner(System.in);
@@ -341,7 +341,7 @@ oder Input-Streams.
 :::
 
 
-## _Try_-with-Resources
+# _Try_-with-Resources
 
 ```java
 try (Scanner myScanner = new Scanner(System.in)) {
@@ -357,7 +357,7 @@ werden. Diese Ressourcen müssen `java.io.Closeable` implementieren.
 :::
 
 
-## Eigene Exceptions
+# Eigene Exceptions
 
 ```java
 // Checked Exception
@@ -392,7 +392,7 @@ wie die Exceptions aus dem JDK.
 :::
 
 
-## Stilfrage: Wie viel Code im _Try_?
+# Stilfrage: Wie viel Code im _Try_?
 
 ```java
 int getFirstLineAsInt(String pathToFile) {
@@ -410,7 +410,7 @@ int getFirstLineAsInt(String pathToFile) {
 ::: notes
 Hier lassen sich verschiedene "Ausbaustufen" unterscheiden.
 
-### Handling an den Aufrufer übergeben
+## Handling an den Aufrufer übergeben
 
 ```java
 int getFirstLineAsIntV1(String pathToFile) throws FileNotFoundException, IOException {
@@ -431,7 +431,7 @@ deklarieren.
 _Anmerkung_: Da `FileNotFoundException` eine Spezialisierung von `IOException` ist,
 reicht es aus, lediglich die `IOException` zu deklarieren.
 
-### Jede Exception einzeln fangen und bearbeiten
+## Jede Exception einzeln fangen und bearbeiten
 
 ```java
 int getFirstLineAsIntV2(String pathToFile) {
@@ -477,7 +477,7 @@ Wenn Sie solchen Code schreiben oder sehen, ist das ein Anzeichen, dass auf dies
 nicht sinnvoll mit dem Fehler umgegangen werden kann und dass man ihn besser an den
 Aufrufer weiter reichen sollte (siehe nächste Folie).
 
-### Funktionaler Teil in gemeinsames _Try_ und mehrstufiges _Catch_
+## Funktionaler Teil in gemeinsames _Try_ und mehrstufiges _Catch_
 
 ```java
 int getFirstLineAsIntV3(String pathToFile) {
@@ -509,7 +509,7 @@ Fehler.
 :::
 
 
-## Stilfrage: Wo fange ich die Exception?
+# Stilfrage: Wo fange ich die Exception?
 
 ```java
 private static void methode1(int x) throws IOException {
@@ -544,16 +544,16 @@ kann ich sinnvoll auf den Fehler reagieren?
 :::
 
 
-## Stilfrage: Wann checked, wann unchecked
+# Stilfrage: Wann checked, wann unchecked
 
-### "Checked" Exceptions
+## "Checked" Exceptions
 
 *   Für erwartbare Fehlerfälle, deren Ursprung nicht im Programm selbst liegt
 *   Aufrufer kann sich von der Exception erholen
 
 \bigskip
 
-### "Unchecked" Exceptions
+## "Unchecked" Exceptions
 
 *   Logische Programmierfehler ("Versagen" des Programmcodes)
 *   Aufrufer kann sich von der Exception vermutlich nicht erholen
@@ -563,7 +563,7 @@ Vergleiche ["Unchecked Exceptions — The Controversy"](https://dev.java/learn/e
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   `Error` und `Exception`: System vs. Programm
 *   Checked und unchecked Exceptions: `Exception` vs. `RuntimeException`

--- a/lecture/java-classic/generics-bounds-wildcards.md
+++ b/lecture/java-classic/generics-bounds-wildcards.md
@@ -85,7 +85,7 @@ challenges: |
 ---
 
 
-## Bounds: Einschränken der generischen Typen
+# Bounds: Einschränken der generischen Typen
 
 ```java
 public class Cps<E extends Number> {
@@ -115,7 +115,7 @@ _Anmerkung_: Der Typ-Parameter ist analog auch mit `super` (nach unten) einschr�
 :::
 
 
-## Wildcards: Dieser Typ ist mir nicht so wichtig
+# Wildcards: Dieser Typ ist mir nicht so wichtig
 
 \bigskip
 
@@ -153,7 +153,7 @@ Weitere Eigenschaften:
 @Bloch2018: Nur für Parameter und nicht für Rückgabewerte nutzen!
 
 
-## Hands-On: Ausgabe für generische Listen
+# Hands-On: Ausgabe für generische Listen
 
 Ausgabe für Listen gesucht, die sowohl Elemente der Klasse `A` als auch
 Elemente der Klasse `B` enthalten [können]{.notes}
@@ -180,7 +180,7 @@ public class X {
  auch das Video zum vierten Teil "Generics und Polymorphie" anschauen]{.notes}
 
 ::::::::: notes
-### Erster Versuch (_A_ und _B_ und _main()_ wie oben)
+## Erster Versuch (_A_ und _B_ und _main()_ wie oben)
 
 ```java
 public class X {
@@ -196,7 +196,7 @@ Vererbung ...)!
 
 [Beispiel wildcards.v1.X]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/wildcards/v1/X.java"}
 
-### Zweiter Versuch mit Wildcards (_A_ und _B_ und _main()_ wie oben)
+## Zweiter Versuch mit Wildcards (_A_ und _B_ und _main()_ wie oben)
 
 ```java
 public class X {
@@ -216,7 +216,7 @@ Typen aufrufen ...
 
 [Beispiel wildcards.v2.X]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/wildcards/v2/X.java"}
 
-### Dritter Versuch (Lösung) mit Wildcards und Bounds (_A_ und _B_ und _main()_ wie oben)
+## Dritter Versuch (Lösung) mit Wildcards und Bounds (_A_ und _B_ und _main()_ wie oben)
 
 ```java
 public class X {
@@ -235,7 +235,7 @@ und hat dann auch wieder die `printInfo`-Methode zur Verfügung ...
 [Konsole wildcards.v3.X]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/tree/master/lecture/java-classic/src/wildcards/v3"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Ein Wildcard (`?`) als Typ-Parameter steht für einen beliebigen Typ
     -   Ist in Klasse oder Methode dann aber nicht mehr zugreifbar

--- a/lecture/java-classic/generics-classes-methods.md
+++ b/lecture/java-classic/generics-classes-methods.md
@@ -35,7 +35,7 @@ attachments:
 ---
 
 
-## Generische Strukturen
+# Generische Strukturen
 
 ```java
 Vector speicher = new Vector();
@@ -84,7 +84,7 @@ Vorteile beim Einsatz von Generics:
 :::
 
 
-## Generische Klassen/Interfaces definieren
+# Generische Klassen/Interfaces definieren
 
 *   **Definition**: "`<Typ>`" hinter Klassennamen
 
@@ -115,7 +115,7 @@ Vorteile beim Einsatz von Generics:
 
 
 ::::::::: notes
-## Generische Klassen instantiieren
+# Generische Klassen instantiieren
 
 *   Typ-Parameter in spitzen Klammern hinter Klasse bzw. Interface
 
@@ -126,7 +126,7 @@ Vorteile beim Einsatz von Generics:
 :::::::::
 
 
-## Beispiel I: Einfache generische Klassen
+# Beispiel I: Einfache generische Klassen
 
 \bigskip
 
@@ -152,7 +152,7 @@ b.foo("huhu");  // Fehlermeldung vom Compiler
 ::::::::: notes
 [Beispiel: classes.GenericClasses]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/classes/GenericClasses.java"}
 
-### Typ-Inferenz
+## Typ-Inferenz
 
 Typ-Parameter kann bei `new()` auf der rechten Seite oft weggelassen werden
 => **Typ-Inferenz**
@@ -165,7 +165,7 @@ Tutor<String> x = new Tutor<>();  // <>: "Diamantoperator"
 :::::::::
 
 
-## Beispiel II: Vererbung mit Typparametern
+# Beispiel II: Vererbung mit Typparametern
 
 ```java
 interface Fach<T1, T2> {
@@ -194,7 +194,7 @@ nicht "in der Luft hängen" (siehe auch nächste Folie)!
 :::
 
 
-## Beispiel III: Überschreiben/Überladen von Methoden
+# Beispiel III: Überschreiben/Überladen von Methoden
 
 ```java
 class Mensch { ... }
@@ -212,7 +212,7 @@ class Tutor extends Studi<Mensch> {
 ```
 
 
-## Vorsicht: So geht es nicht!
+# Vorsicht: So geht es nicht!
 
 ```java
 class Foo<T> extends T { ... }
@@ -227,7 +227,7 @@ class Fluppie<T> extends Wuppie<S> { ... }
 :::
 
 
-## Generische Methoden definieren
+# Generische Methoden definieren
 
 *   "`<Typ>`" vor Rückgabetyp
 
@@ -252,21 +252,21 @@ class Fluppie<T> extends Wuppie<S> { ... }
     ```
 
 
-## Aufruf generischer Methoden
+# Aufruf generischer Methoden
 
 ::::::::: notes
-### Aufruf
+## Aufruf
 
 *   Aufruf mit Typ-Parameter vor Methodennamen, oder
 *   Inferenz durch Compiler
 
-### Finden der richtigen Methode durch den Compiler
+## Finden der richtigen Methode durch den Compiler
 
 1.  Zuerst Suche nach exakt passender Methode,
 2.  danach passend mit Konvertierungen
     => Compiler sucht gemeinsame Oberklasse in Typhierarchie
 
-### Beispiel
+## Beispiel
 :::::::::
 
 ```java
@@ -334,7 +334,7 @@ public class GenericMethods {
 :::::::::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Begriffe:
     *   Generischer Typ: `Stack<T>`

--- a/lecture/java-classic/generics-polymorphism.md
+++ b/lecture/java-classic/generics-polymorphism.md
@@ -32,7 +32,7 @@ attachments:
 ---
 
 
-## Generische Polymorphie
+# Generische Polymorphie
 
 ::: center
 `B<E> extends A<E>`
@@ -69,7 +69,7 @@ sein.
 :::
 
 
-## Polymorphie bei Generics bezieht sich nur auf Typ!
+# Polymorphie bei Generics bezieht sich nur auf Typ!
 
 \bigskip
 
@@ -100,7 +100,7 @@ s.push(new Double(2.0)); // waere dann auch erlaubt ...
 :::
 
 
-## Abgrenzung: Polymorphie bei Arrays
+# Abgrenzung: Polymorphie bei Arrays
 
 ::: center
 Wenn "`B extends A`" dann "`B[] extends A[]`"
@@ -138,7 +138,7 @@ Compiler-Prüfung. Da würde das von Arrays bekannte Verhalten Probleme machen .
 :::
 
 
-## Arrays vs. parametrisierte Klassen
+# Arrays vs. parametrisierte Klassen
 
 => Keine Arrays mit parametrisierten Klassen!
 
@@ -157,7 +157,7 @@ Laufzeit Typinformationen, die aber durch die Typ-Löschung entfernt werden.
 :::
 
 
-## Diskussion Vererbung vs. Generics
+# Diskussion Vererbung vs. Generics
 
 **Vererbung:**
 
@@ -174,7 +174,7 @@ Laufzeit Typinformationen, die aber durch die Typ-Löschung entfernt werden.
 *   Beispiel: Datenstrukturen, Algorithmen generisch realisieren
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Generics: Vererbung und Überladen möglich, aber: \newline
     **Aus "`U extends O`" folgt **nicht** "`A<U> extends A<O>`"**

--- a/lecture/java-classic/generics-type-erasure.md
+++ b/lecture/java-classic/generics-type-erasure.md
@@ -30,7 +30,7 @@ attachments:
 ---
 
 
-## Typ-Löschung (_Type-Erasure_)
+# Typ-Löschung (_Type-Erasure_)
 
 ::: notes
 Der Compiler ersetzt nach Prüfung der Typen und ihrer Verwendung alle Typ-Parameter
@@ -93,7 +93,7 @@ Die obere Schranke meist `Object` => `new T()` verboten/sinnfrei (s.u.)!
 :::
 
 
-## Type-Erasure bei Nutzung von Bounds
+# Type-Erasure bei Nutzung von Bounds
 
 :::::: columns
 ::: column
@@ -135,7 +135,7 @@ class Cps {
 ::::::
 
 
-## Raw-Types: Ich mag meine Generics "well done" :-)
+# Raw-Types: Ich mag meine Generics "well done" :-)
 
 Raw-Types: Instanziierung ohne Typ-Parameter => `Object`
 
@@ -149,7 +149,7 @@ Stack s = new Stack(); // Stack von Object-Objekten
 *   Nutzung wird nicht empfohlen! (Warum?)
 
 ::: notes
-### Anmerkung
+## Anmerkung
 
 Raw-Types darf man zwar selbst im Quellcode verwenden (so wie im Beispiel
 hier), **sollte** die Verwendung aber vermeiden wegen der Typ-Unsicherheit:
@@ -168,7 +168,7 @@ da, weil es dort noch keine Generics gab (wurden erst mit Java6 eingeführt).
 :::
 
 
-## Folgen der Typ-Löschung: _new_
+# Folgen der Typ-Löschung: _new_
 
 ::: center
 `new` mit parametrisierten Klassen ist nicht erlaubt!
@@ -198,7 +198,7 @@ Cast-Typ eigentlich mitbringt ...
 :::
 
 
-## Folgen der Typ-Löschung: _static_
+# Folgen der Typ-Löschung: _static_
 
 ::: center
 `static` mit generischen Typen ist nicht erlaubt!
@@ -227,7 +227,7 @@ sich die statischen Attribute teilen \newline (Typ zur Laufzeit unklar!).
 *Hinweis*: Generische (statische) Methoden sind erlaubt.
 
 
-## Folgen der Typ-Löschung: _instanceof_
+# Folgen der Typ-Löschung: _instanceof_
 
 ::: center
 `instanceof` mit parametrisierten Klassen ist nicht erlaubt!
@@ -270,7 +270,7 @@ void printType(Fach p) {
 ::::::
 
 
-## Folgen der Typ-Löschung: _.class_
+# Folgen der Typ-Löschung: _.class_
 
 ::: center
 `.class` mit parametrisierten Klassen ist nicht erlaubt!
@@ -292,7 +292,7 @@ x = (a.getClass() == b.getClass());               // true
 Grund: Es gibt nur `List.class` (und kein `List<String>.class` bzw. `List<Integer>.class`)!
 
 
-## Wrap-Up
+# Wrap-Up
 
 -   Generics existieren eigentlich nur auf Quellcode-Ebene
 -   "Type-Erasure":

--- a/lecture/java-classic/logging.md
+++ b/lecture/java-classic/logging.md
@@ -120,7 +120,7 @@ challenges: |
 ---
 
 
-## Wie prüfen Sie die Werte von Variablen/Objekten?
+# Wie prüfen Sie die Werte von Variablen/Objekten?
 
 1.  Debugging
     *   Beeinflusst Code nicht
@@ -142,7 +142,7 @@ challenges: |
         `java.util.logging` (JDK), *log4j* (Apache), *SLF4J*, *Logback*, ...
 
 
-## Java Logging API - Überblick
+# Java Logging API - Überblick
 
 Paket `java.util.logging`
 
@@ -167,7 +167,7 @@ Log-Level) nach weiteren Kriterien filtern kann.
 [Konsole: logging.LoggingDemo]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/logging/LoggingDemo.java"}
 
 
-## Erzeugen neuer Logger
+# Erzeugen neuer Logger
 
 ```java
 import java.util.logging.Logger;
@@ -191,7 +191,7 @@ Logger l = Logger.getLogger(MyClass.class.getName());
     *   **Alternativen**: Funktionale Namen wie "XML", "DB", "Security"
 
 
-## Ausgabe von Logmeldungen
+# Ausgabe von Logmeldungen
 
 ```java
 public void log(Level level, String msg);
@@ -220,7 +220,7 @@ public void log(Level level, String msg);
     ```
 
 
-## Wichtigkeit von Logmeldungen: Stufen
+# Wichtigkeit von Logmeldungen: Stufen
 
 *   `java.util.logger.Level` definiert 7 Stufen:
     *   `SEVERE`, `WARNING`, `INFO`, `CONFIG`, `FINE`, `FINER`, `FINEST` \newline
@@ -242,7 +242,7 @@ ab `INFO` geloggt? Wer erzeugt eigentlich die Ausgaben?!
 :::
 
 
-## Jemand muss die Arbeit machen ...
+# Jemand muss die Arbeit machen ...
 
 \bigskip
 
@@ -275,7 +275,7 @@ angezeigt (ab `INFO` aufwärts)?!
 :::
 
 
-## Ich ... bin ... Dein ... Vater ...
+# Ich ... bin ... Dein ... Vater ...
 
 *   Logger bilden **Hierarchie** über Namen
     *   Trenner für Namenshierarchie: "`.`" (analog zu Packages)  [=> mit jedem "`.`" wird eine weitere Ebene der Hierarchie aufgemacht ...]{.notes}
@@ -293,7 +293,7 @@ angezeigt (ab `INFO` aufwärts)?!
 [Konsole: logging.LoggingParent; Tafel: Skizze Logger-Baum]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/logging/LoggingParent.java"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Java Logging API im Paket `java.util.logging`
 

--- a/lecture/java-classic/reflection.md
+++ b/lecture/java-classic/reflection.md
@@ -59,7 +59,7 @@ challenges: |
     Ihre Operation-Klassen dürfen Sie nicht vorher bekannt machen. Diese müssen in einem vom aktuellen Projekt separierten Ordner/Projekt liegen.
 ---
 
-## Ausgaben und Einblicke zur Laufzeit
+# Ausgaben und Einblicke zur Laufzeit
 
 ```java
 public class FactoryBeispielTest {
@@ -89,7 +89,7 @@ schauen Sie doch bitte einfach kurz im Handout zu Annotationen nach :-)
 :::
 
 
-## Wer bin ich? ... Informationen über ein Programm (zur Laufzeit)
+# Wer bin ich? ... Informationen über ein Programm (zur Laufzeit)
 
 ::: center
 `java.lang.Class`: Metadaten über Klassen
@@ -128,7 +128,7 @@ Dies umfasst u.a.:
 :::
 
 
-## Vorgehen
+# Vorgehen
 
 1.  Gewünschte Klasse über ein `Class`-Objekt laden
 
@@ -155,7 +155,7 @@ Damit werden die Programme dynamischer.
 :::
 
 
-## Schritt 1: _Class_-Objekt erzeugen und Klasse laden
+# Schritt 1: _Class_-Objekt erzeugen und Klasse laden
 
 ```java
 // Variante 1 (package.MyClass dynamisch zur Laufzeit laden)
@@ -188,7 +188,7 @@ Laufzeit.
 :::
 
 
-## Schritt 2: In die Klasse reinschauen
+# Schritt 2: In die Klasse reinschauen
 
 ```java
 // Studi-Klasse dynamisch (nach-) laden
@@ -230,7 +230,7 @@ Analog können Sie weitere Eigenschaften einer Klasse abfragen, beispielsweise A
 :::
 
 
-## Schritt 3: Instanz der geladenen Klasse erzeugen
+# Schritt 3: Instanz der geladenen Klasse erzeugen
 
 ```java
 // Class-Objekt erzeugen
@@ -251,18 +251,18 @@ Studi s = (Studi) ctor.newInstance("Beate", 42);
 ```
 
 ::: notes
-### Parameterlose, öffentliche Konstruktoren:
+## Parameterlose, öffentliche Konstruktoren:
 
 *   `Class<?>.newInstance()` (seit Java9 _deprecated_!)
 *   `Class<?>.getConstructor()` => `Constructor<?>.newInstance()`
 
-### Sonstige Konstruktoren:
+## Sonstige Konstruktoren:
 
 Passenden Konstruktor explizit holen: `Class<?>.getDeclaredConstructor(Class<?>[])`,
 Parametersatz zusammenbasteln (hier nicht dargestellt)
 und aufrufen `Constructor<?>.newInstance(...)`
 
-### Unterschied _new_ und _Constructor.newInstance()_:
+## Unterschied _new_ und _Constructor.newInstance()_:
 
 `new` ist nicht identisch zu `Constructor.newInstance()`: `new`
 kann Dinge wie Typ-Prüfung  oder Auto-Boxing mit erledigen, während
@@ -273,7 +273,7 @@ Vgl. [docs.oracle.com/javase/tutorial/reflect/member/ctorTrouble.html](https://d
 :::
 
 
-## Schritt 4: Methoden aufrufen ...
+# Schritt 4: Methoden aufrufen ...
 
 ```java
 // Studi-Klasse dynamisch (nach-) laden
@@ -300,7 +300,7 @@ einmal selbst in die API hinein.
 [Demo: reflection.ReflectionDemo]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/reflection/ReflectionDemo.java"}
 
 
-## Hinweis: Klassen außerhalb des Classpath laden
+# Hinweis: Klassen außerhalb des Classpath laden
 
 ```java
 File folder = new File("irgendwo");
@@ -327,7 +327,7 @@ dessen Methode `loadClass()`.
 :::
 
 
-## Licht und Schatten
+# Licht und Schatten
 
 **Nützlich**:
 
@@ -350,7 +350,7 @@ dessen Methode `loadClass()`.
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Inspektion von Programmen zur Laufzeit: **Reflection**
     *   `java.lang.Class`: Metadaten über Klassen

--- a/lecture/java-classic/regexp.md
+++ b/lecture/java-classic/regexp.md
@@ -75,7 +75,7 @@ challenges: |
 ---
 
 
-## Suchen in Strings
+# Suchen in Strings
 
 Gesucht ist ein Programm zum Extrahieren von Telefonnummern aus E-Mails.
 
@@ -95,13 +95,13 @@ Vorwahl und ggf. Ländervorwahl) aufschreiben kann:
     +49(30)123456-789, +49 (30) 123 456 - 789, ...
 
 
-## Definition Regulärer Ausdruck
+# Definition Regulärer Ausdruck
 
 > Ein **regulärer Ausdruck** ist eine Zeichenkette, die zur Beschreibung von
 > Zeichenketten dient.
 
 ::: notes
-### Anwendungen
+## Anwendungen
 
 *   Finden von Bestandteilen in Zeichenketten
 *   Aufteilen von Strings in Tokens
@@ -111,7 +111,7 @@ Vorwahl und ggf. Ländervorwahl) aufschreiben kann:
 :::
 
 
-## Einfachste reguläre Ausdrücke
+# Einfachste reguläre Ausdrücke
 
 | **Zeichenkette** | **Beschreibt**         |
 |:-----------------|:-----------------------|
@@ -123,7 +123,7 @@ Vorwahl und ggf. Ländervorwahl) aufschreiben kann:
 | `\\`             | Backslash              |
 
 ::: notes
-### Beispiel
+## Beispiel
 :::
 
 *   `abc` => "abc"
@@ -131,7 +131,7 @@ Vorwahl und ggf. Ländervorwahl) aufschreiben kann:
 *   `a\\bc` => "a\\bc"
 
 ::: notes
-### Anmerkung
+## Anmerkung
 
 In Java-Strings leitet der Backslash eine zu interpretierende Befehlssequenz ein.
 Deshalb muss der Backslash i.d.R. geschützt ("escaped") werden.
@@ -139,7 +139,7 @@ Deshalb muss der Backslash i.d.R. geschützt ("escaped") werden.
 :::
 
 
-## Zeichenklassen
+# Zeichenklassen
 
 | **Zeichenkette** | **Beschreibt**                                           |
 |:-----------------|:---------------------------------------------------------|
@@ -151,7 +151,7 @@ Deshalb muss der Backslash i.d.R. geschützt ("escaped") werden.
 | `[a-z&&[^m-p]]`  | "a" bis "z", außer "m" bis "p": `[a-lq-z]` (Subtraktion) |
 
 ::: notes
-### Beispiel
+## Beispiel
 :::
 
 *   `[abc]` => "a" oder "b" oder "c"
@@ -160,7 +160,7 @@ Deshalb muss der Backslash i.d.R. geschützt ("escaped") werden.
 *   `A[a-c]` => "Aa", "Ab" oder "Ac"
 
 
-## Vordefinierte Ausdrücke
+# Vordefinierte Ausdrücke
 
 | **Zeichenkette** | **Beschreibt**                               |
 |:-----------------|:---------------------------------------------|
@@ -174,14 +174,14 @@ Deshalb muss der Backslash i.d.R. geschützt ("escaped") werden.
 | `\S`             | jedes Zeichen außer Whitespaces: `[^\s]`     |
 
 ::: notes
-### Beispiel
+## Beispiel
 :::
 
 *   `\d\d\d\d\d` => "12345"
 *   `\w\wA` => "aaA", "a0A", "a_A", ...
 
 
-## Nutzung in Java
+# Nutzung in Java
 
 \bigskip
 
@@ -248,7 +248,7 @@ Sie im Java-String "`a\\\\bc`" schreiben!
 [Demo: regexp.MatchFind]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/regexp/MatchFind.java"}
 
 
-## Unterschied zw. Finden und Matchen
+# Unterschied zw. Finden und Matchen
 
 *   `Matcher#find`:
 
@@ -264,7 +264,7 @@ Sie im Java-String "`a\\\\bc`" schreiben!
 \bigskip
 
 ::: notes
-### Beispiel
+## Beispiel
 :::
 
 *   Regulärer Ausdruck: `abc`, Suchstring: "blah blah abc blub"
@@ -272,7 +272,7 @@ Sie im Java-String "`a\\\\bc`" schreiben!
     *   `Matcher#matches`: kein Match - Suchstring entspricht nicht dem Muster
 
 
-## Quantifizierung
+# Quantifizierung
 
 | **Zeichenkette** | **Beschreibt**                                   |
 |:-----------------|:-------------------------------------------------|
@@ -284,14 +284,14 @@ Sie im Java-String "`a\\\\bc`" schreiben!
 | `X{n,m}`         | zwischen $n$ und $m$ Vorkommen von "X"           |
 
 ::: notes
-### Beispiel
+## Beispiel
 :::
 
 *   `\d{5}` => "12345"
 *   `-?\d+\.\d*` => ???
 
 
-## Interessante Effekte
+# Interessante Effekte
 
 ```java
 Pattern p = Pattern.compile("A.*A");
@@ -317,7 +317,7 @@ Dies liegt am "*greedy*" Verhalten der Quantifizierer.
 :::
 
 
-## Nicht gierige Quantifizierung mit "?"
+# Nicht gierige Quantifizierung mit "?"
 
 \bigskip
 
@@ -327,7 +327,7 @@ Dies liegt am "*greedy*" Verhalten der Quantifizierer.
 | `X+?`            | non-greedy Variante von `X+` |
 
 ::: notes
-### Beispiel
+## Beispiel
 :::
 
 *   Suchstring "A 12 A 45 A":
@@ -347,7 +347,7 @@ Dies liegt am "*greedy*" Verhalten der Quantifizierer.
         :::
 
 
-## (Fangende) Gruppierungen
+# (Fangende) Gruppierungen
 
 `Studi{2}` passt nicht auf "StudiStudi" (!)
 
@@ -374,7 +374,7 @@ Gruppierungen durch Klammern verwenden!
 :::
 
 ::: notes
-### Beispiel
+## Beispiel
 :::
 
 *   `(A)(B(C))`
@@ -413,7 +413,7 @@ bei Vorliegen eines Matches auf die Gruppen zugreifen.
 [Demo: regexp.Groups]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/regexp/Groups.java"}
 
 
-## Gruppen und Backreferences
+# Gruppen und Backreferences
 
 Matche zwei Ziffern, gefolgt von den selben zwei Ziffern
 
@@ -447,7 +447,7 @@ Matche zwei Ziffern, gefolgt von den selben zwei Ziffern
 [Demo: regexp.Backref]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/regexp/Backref.java"}
 
 
-## Beispiel Gruppen und Backreferences
+# Beispiel Gruppen und Backreferences
 
 Regulärer Ausdruck: Namen einer Person matchen, wenn Vor- und Nachname identisch sind.
 
@@ -458,7 +458,7 @@ Lösung: `([A-Z][a-zA-Z]*)\s\1`
 
 
 ::: notes
-## Umlaute und reguläre Ausdrücke
+# Umlaute und reguläre Ausdrücke
 
 *   Keine vordefinierte Abkürzung für Umlaute (wie etwa `\d`)
 
@@ -488,7 +488,7 @@ Lösung: `([A-Z][a-zA-Z]*)\s\1`
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   RegExp: Zeichenketten, die andere Zeichenketten beschreiben
 *   `java.util.regex.Pattern` und `java.util.regex.Matcher`

--- a/lecture/java-classic/serialisation.md
+++ b/lecture/java-classic/serialisation.md
@@ -206,7 +206,7 @@ challenges: |
 ---
 
 
-## Motivation: Persistierung von Objekten und Spielzuständen
+# Motivation: Persistierung von Objekten und Spielzuständen
 
 ```java
 public class Studi {
@@ -231,7 +231,7 @@ fortsetzen kann?
 :::
 
 
-## Serialisierung von Objekten
+# Serialisierung von Objekten
 
 *   Klassen müssen Marker-Interface `Serializable` implementieren
 
@@ -277,7 +277,7 @@ fortsetzen kann?
     :::
 
 
-## Einfaches Beispiel
+# Einfaches Beispiel
 
 ```java
 public class Studi implements Serializable {
@@ -303,7 +303,7 @@ public class Studi implements Serializable {
 ```
 
 
-## Bedingungen für Objekt-Serialisierung
+# Bedingungen für Objekt-Serialisierung
 
 *   Klassen implementieren Marker-Interface `Serializable`
 *   Alle Attribute müssen ebenfalls serialisierbar sein (oder Deklaration "`transient`")
@@ -313,14 +313,14 @@ public class Studi implements Serializable {
 *   Serialisierbarkeit vererbt sich
 
 
-## Ausnahmen
+# Ausnahmen
 
 *   Als `static` deklarierte Attribute werden nicht serialisiert
 *   Als `transient` deklarierte Attribute werden nicht serialisiert
 *   Nicht serialisierbare Attribut-Typen führen zu `NotSerializableException`
 
 
-## Version-UID
+# Version-UID
 
 ```java
 static final long serialVersionUID = 42L;
@@ -348,7 +348,7 @@ man aber auch selbst darauf achten, diese zu verändern, wenn sich wesentliche s
 
 
 ::: notes
-## Bemerkungen
+# Bemerkungen
 
 Es existieren diverse weitere Fallstricke und Probleme, siehe [@Bloch2018] Kapitel 11 "Serialization".
 
@@ -374,7 +374,7 @@ Weitere Links:
 [Demo: serial.SerializableStudi]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/serial/SerializableStudi.java"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Markerinterface `Serializable` schaltet Serialisierbarkeit frei
 

--- a/lecture/java-classic/threads-highlevel.md
+++ b/lecture/java-classic/threads-highlevel.md
@@ -49,7 +49,7 @@ attachments:
 ---
 
 
-## Explizite Lock-Objekte
+# Explizite Lock-Objekte
 
 ::: notes
 Sie kennen bereits die Synchronisierung mit dem Schlüsselwort `synchronized`.
@@ -116,10 +116,10 @@ Nachteile:
 [Demo: lock.*]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/tree/master/lecture/java-classic/src/lock/"}
 
 
-## Thread-Management: Executor-Interface und Thread-Pools
+# Thread-Management: Executor-Interface und Thread-Pools
 
 ::::::::: notes
-### Wiederverwendung von Threads
+## Wiederverwendung von Threads
 
 *   Normale Threads sind immer Einmal-Threads: Man kann sie nur **einmal** in
     ihrem Leben starten (auch wenn das Objekt anschließend noch auf
@@ -133,7 +133,7 @@ Nachteile:
 *   Idee: Threads wiederverwenden und Thread-Management auslagern
     => **Executor-Interface** und **Thread-Pool**
 
-### Executor-Interface
+## Executor-Interface
 
 ```java
 public interface Executor {
@@ -146,7 +146,7 @@ public interface Executor {
     wiederverwenden):
     `e.execute(r);` => entspricht in der Wirkung `(new Thread(r)).start();`
 
-### Thread-Pool hält Menge von "Worker-Threads"
+## Thread-Pool hält Menge von "Worker-Threads"
 
 *   Statische Methoden von `java.util.concurrent.Executors` erzeugen
     Thread-Pools mit verschiedenen Eigenschaften:
@@ -185,7 +185,7 @@ pool.shutdown();    // Feierabend :)
 
 
 ::::::::: notes
-### Hintergrund (vereinfacht)
+## Hintergrund (vereinfacht)
 
 Der Thread-Pool reserviert sich "nackten" Speicher, der der Größe von $n$
 Threads entspricht, und "prägt" die Objektstruktur durch einen Cast direkt auf
@@ -194,7 +194,7 @@ wohlbekannt und schnell (vgl. Thema Speicherverwaltung in der LV
 "Systemprogrammierung"). In Java wird dies durch eine wohldefinierte
 Schnittstelle vor dem Nutzer verborgen.
 
-### Ausblick
+## Ausblick
 
 Hier haben wir nur die absoluten Grundlagen angerissen. Wir können auch
 `Callables` anstatt von `Runnables` übergeben, auf Ergebnisse aus der Zukunft
@@ -206,7 +206,7 @@ Oracle-Dokumentation oder auch [@Ullenboom2021] (insbesondere den Abschnitt 16.4
 :::::::::
 
 
-## Fork/Join-Framework: Teile und Herrsche
+# Fork/Join-Framework: Teile und Herrsche
 
 ::: notes
 Spezieller Thread-Pool zur rekursiven Bearbeitung parallelisierbarer Tasks
@@ -244,10 +244,10 @@ public class RecursiveTask extends ForkJoinTask<V> {
 [Demo: forkjoin.ForkJoin]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/forkjoin/ForkJoin.java"}
 
 
-## Swing und Threads
+# Swing und Threads
 
 ::: notes
-### Lange Berechnungen in Listenern blockieren Swing-GUI
+## Lange Berechnungen in Listenern blockieren Swing-GUI
 
 *   Problem: Events werden durch **einen** *Event Dispatch Thread* (EDT)
     **sequentiell** bearbeitet
@@ -255,7 +255,7 @@ public class RecursiveTask extends ForkJoinTask<V> {
 *   **Achtung**: Swing ist **nicht Thread-safe**! Komponenten nicht
     durch verschiedene Threads manipulieren!
 
-### Lösung
+## Lösung
 
 => `javax.swing.SwingWorker` ist eine spezielle Thread-Klasse, eng mit Swing/Event-Modell verzahnt.
 :::
@@ -271,7 +271,7 @@ public class RecursiveTask extends ForkJoinTask<V> {
     *   `SwingWorker#get`: Return-Wert von `doInBackground` abfragen
 
 ::: notes
-### Anmerkungen
+## Anmerkungen
 
 *   `SwingWorker#done` ist optional: *kann* überschrieben werden
     *   Beispielweise, wenn nach Beendigung der langwierigen Berechnung
@@ -286,7 +286,7 @@ public class RecursiveTask extends ForkJoinTask<V> {
 [Demo: misc.SwingWorkerDemo]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/misc/SwingWorkerDemo.java"}
 
 
-## Letzte Worte :-)
+# Letzte Worte :-)
 
 *   Viele weitere Konzepte
     *   Semaphoren, Monitore, ...
@@ -314,7 +314,7 @@ public class RecursiveTask extends ForkJoinTask<V> {
 *   Thread-safe bedeutet **Overhead** (Synchronisierung)!
 
 
-## Wrap-Up
+# Wrap-Up
 
 Multi-Threading auf höherem Level: Thread-Pools und Fork/Join-Framework
 

--- a/lecture/java-classic/threads-intro.md
+++ b/lecture/java-classic/threads-intro.md
@@ -62,7 +62,7 @@ attachments:
 ---
 
 
-## 42
+# 42
 
 ![](images/screenshot_swingworker.png){width="80%"}
 
@@ -74,15 +74,15 @@ Wert 42 ausprobieren (ist zeitlich ganz gut)
 
 
 ::: notes
-## Einführung in nebenläufige Programmierung
+# Einführung in nebenläufige Programmierung
 :::
 
 ::: notes
-### Traditionelle Programmierung
+## Traditionelle Programmierung
 ::::
 
 ::: slides
-## Traditionelle Programmierung
+# Traditionelle Programmierung
 :::
 
 ::: notes
@@ -110,11 +110,11 @@ public class Traditional {
 
 
 ::: notes
-### Nebenläufige Programmierung
+## Nebenläufige Programmierung
 ::::
 
 ::: slides
-## Nebenläufige Programmierung
+# Nebenläufige Programmierung
 :::
 
 ::: notes
@@ -151,7 +151,7 @@ public class Threaded extends Thread {
 [Demo: intro.Threaded]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/intro/Threaded.java"}
 
 
-## Erzeugen von Threads
+# Erzeugen von Threads
 
 *   Ableiten von `Thread` oder Implementierung von `Runnable`
 
@@ -163,12 +163,12 @@ public class Threaded extends Thread {
 [Demo: creation.*]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/creation/"}
 
 ::: notes
-### Ableiten von _Thread_
+## Ableiten von _Thread_
 
 *    `start()` startet den Thread und sorgt für Ausführung von `run()`
 *    `start()` nur einmal aufrufen
 
-### Implementierung von _Runnable_
+## Implementierung von _Runnable_
 
 *   Ebenfalls `run()` implementieren
 *   Neues `Thread`-Objekt erzeugen, Konstruktor das eigene Runnable übergeben
@@ -179,7 +179,7 @@ Vorteil von `Runnable`: Ist ein Interface, d.h. man kann noch von einer anderen 
 :::
 
 
-## Zustandsmodell von Threads (vereinfacht)
+# Zustandsmodell von Threads (vereinfacht)
 
 ::: notes
 Threads haben einen Lebenszyklus: Nach dem Erzeugen der Objekte mit `new` wird
@@ -216,14 +216,14 @@ ausführliche Darstellung.
 
 \bigskip
 
-### Threads können wie normale Objekte kommunizieren
+## Threads können wie normale Objekte kommunizieren
 
 *   Zugriff auf (`public`) Attribute [(oder eben über Methoden)]{.notes}
 *   Aufruf von Methoden
 
 \bigskip
 
-### Threads können noch mehr
+## Threads können noch mehr
 
 *   Eine Zeitlang schlafen: `Thread.sleep(<duration_ms>)`
 
@@ -273,7 +273,7 @@ besprochen.
 [Demo: intro.Join]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/intro/Join.java"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 Threads sind weitere Kontrollflussfäden, von Java-VM (oder (selten) von OS) verwaltet
 

--- a/lecture/java-classic/threads-synchronisation.md
+++ b/lecture/java-classic/threads-synchronisation.md
@@ -114,7 +114,7 @@ challenges: |
 ---
 
 
-## Motivation: Verteilter Zugriff auf gemeinsame Ressourcen
+# Motivation: Verteilter Zugriff auf gemeinsame Ressourcen
 
 ```java
 public class Teaser implements Runnable {
@@ -140,7 +140,7 @@ public class Teaser implements Runnable {
 [Demo: synchronised.Teaser]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/synchronised/Teaser.java"}
 
 
-## Zugriff auf gemeinsame Ressourcen: Mehrseitige Synchronisierung
+# Zugriff auf gemeinsame Ressourcen: Mehrseitige Synchronisierung
 
 ```java
 synchronized (<Object reference>) {
@@ -188,7 +188,7 @@ geschützten Bereich einschließen und als Sperr-Objekt das eigene Objekt (`this
 [Demo: synchronised.ObjSync]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/synchronised/ObjSync.java"}
 
 
-## Synchronisierte Methoden
+# Synchronisierte Methoden
 
 :::::: columns
 :::{.column width="40%"}
@@ -238,7 +238,7 @@ Die Methode `incrVal()` könnte entsprechend so umgeschrieben werden:
 [Demo: synchronised.MethodSync]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/synchronised/MethodSync.java"}
 
 
-## Probleme bei der (mehrseitigen) Synchronisierung: Deadlocks
+# Probleme bei der (mehrseitigen) Synchronisierung: Deadlocks
 
 ```java
 public class Deadlock {
@@ -286,16 +286,16 @@ Und schon geht's nicht mehr weiter :-)
 [Demo: synchronised.Deadlock]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/synchronised/Deadlock.java"}
 
 
-## Warten auf andere Threads: Einseitige Synchronisierung
+# Warten auf andere Threads: Einseitige Synchronisierung
 
-### Problem
+## Problem
 
 *   Thread T1 wartet auf Arbeitsergebnis von T2
 *   T2 ist noch nicht fertig
 
 \bigskip
 
-### Mögliche Lösungen
+## Mögliche Lösungen
 
 1.  Aktives Warten (Polling): Permanente Abfrage
     *   Kostet unnötig Rechenzeit
@@ -307,7 +307,7 @@ Und schon geht's nicht mehr weiter :-)
     *   Das ist DIE Lösung für das Problem :)
 
 
-## Einseitige Synchronisierung mit _wait_ und _notify_
+# Einseitige Synchronisierung mit _wait_ und _notify_
 
 *   **wait**: Warten auf Erfüllung einer Bedingung (Thread blockiert):
 
@@ -329,7 +329,7 @@ Und schon geht's nicht mehr weiter :-)
     => Bedingung nach Rückkehr von `wait` erneut prüfen!
 
 ::: notes
-### Eigenschaften von _wait_
+## Eigenschaften von _wait_
 
 *   Thread ruft auf Synchronisations-Objekt die Methode `wait` auf
 *   Prozessor wird entzogen, Thread blockiert
@@ -340,7 +340,7 @@ Und schon geht's nicht mehr weiter :-)
 :::
 
 
-## Einseitige Synchronisierung mit _wait_ und _notify_ (cnt.)
+# Einseitige Synchronisierung mit _wait_ und _notify_ (cnt.)
 
 *   **notify**: Aufwecken von wartenden (blockierten) Threads:
 
@@ -354,7 +354,7 @@ Und schon geht's nicht mehr weiter :-)
     ```
 
 ::: notes
-### Eigenschaften von _notify_ bzw. _notifyAll_
+## Eigenschaften von _notify_ bzw. _notifyAll_
 
 *   Thread ruft auf einem Synchronisations-Objekt die Methode `notify`
     oder `notifyAll` auf
@@ -370,7 +370,7 @@ Und schon geht's nicht mehr weiter :-)
 [Demo: synchronised.Staffel]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-classic/src/synchronised/Staffel.java"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 Synchronisierungsbedarf bei verteiltem Zugriff auf gemeinsame Ressourcen:
 

--- a/lecture/java-modern/defaultmethods.md
+++ b/lecture/java-modern/defaultmethods.md
@@ -71,7 +71,7 @@ challenges: |
 ---
 
 
-## Problem: Etablierte API (Interfaces) erweitern
+# Problem: Etablierte API (Interfaces) erweitern
 
 ```java
 interface Klausur {
@@ -93,7 +93,7 @@ damit unmöglich machen.
 :::
 
 
-## Default-Methoden: Interfaces mit Implementierung
+# Default-Methoden: Interfaces mit Implementierung
 
 ::: notes
 Seit Java8 können Interfaces auch Methoden implementieren.
@@ -128,7 +128,7 @@ Verhalten (implementierten Methoden) auch Zustand über die Attribute gespeicher
 
 
 ::: notes
-## Problem: Mehrfachvererbung
+# Problem: Mehrfachvererbung
 
 Drei Regeln zum Auflösen bei Konflikten:
 
@@ -147,7 +147,7 @@ Auf den folgenden Folien wird dies anhand kleiner Beispiele verdeutlicht.
 [[Hinweis: Mehrfachvererbung]{.ex}]{.slides}
 
 
-## Auflösung Mehrfachvererbung: 1. Klassen gewinnen
+# Auflösung Mehrfachvererbung: 1. Klassen gewinnen
 
 ```java
 interface A {
@@ -178,7 +178,7 @@ einer Oberklasse haben Vorrang von allen Default-Methoden.
 :::
 
 
-## Auflösung Mehrfachvererbung: 2. Sub-Interfaces gewinnen
+# Auflösung Mehrfachvererbung: 2. Sub-Interfaces gewinnen
 
 ```java
 interface A {
@@ -210,7 +210,7 @@ spezialisiert ist.
 :::
 
 
-## Auflösung Mehrfachvererbung: 3. Methode explizit auswählen
+# Auflösung Mehrfachvererbung: 3. Methode explizit auswählen
 
 ```java
 interface A {
@@ -248,7 +248,7 @@ muss man manuell durch die explizite Angabe der gewünschten Methode auflösen.
 :::
 
 
-## Quiz: Was kommt hier raus?
+# Quiz: Was kommt hier raus?
 
 ```java
 interface A {
@@ -281,7 +281,7 @@ gewinnen immer (Regel 1).
 
 
 ::: notes
-## Statische Methoden in Interfaces
+# Statische Methoden in Interfaces
 
 ```java
 public interface Collection<E> extends Iterable<E> {
@@ -322,7 +322,7 @@ public class CollectionsX {
 :::
 
 
-## Interfaces vs. Abstrakte Klassen
+# Interfaces vs. Abstrakte Klassen
 
 *   **Abstrakte Klassen**: Schnittstelle und Verhalten und Zustand
 
@@ -342,7 +342,7 @@ public class CollectionsX {
         **viele** Interfaces implementieren
 
 
-## Wrap-Up
+# Wrap-Up
 
 Seit Java8: Interfaces mit Implementierung: **Default-Methoden**
 

--- a/lecture/java-modern/lambdas.md
+++ b/lecture/java-modern/lambdas.md
@@ -161,7 +161,7 @@ challenges: |
 ---
 
 
-## Problem: Sortieren einer Studi-Liste
+# Problem: Sortieren einer Studi-Liste
 
 ```java
 List<Studi> sl = new ArrayList<>();
@@ -204,7 +204,7 @@ Punkt brauchen wir mehr Anlauf ...
 
 
 ::::::::: notes
-## Erinnerung: Verschachtelte Klassen ("_Nested Classes_")
+# Erinnerung: Verschachtelte Klassen ("_Nested Classes_")
 
 Man kann Klassen innerhalb von Klassen definieren: Verschachtelte Klassen.
 
@@ -218,7 +218,7 @@ Man kann Klassen innerhalb von Klassen definieren: Verschachtelte Klassen.
 
 Sichtbarkeit: Wird u.U. von äußerer Klasse "überstimmt"
 
-### Innere Klassen ("_Inner Classes_")
+## Innere Klassen ("_Inner Classes_")
 
 *   Objekt der äußeren Klasse muss existieren
 *   Innere Klasse ist normales Member der äußeren Klasse
@@ -243,7 +243,7 @@ public class Outer {
 
 [Beispiel mit Iterator als innere Klasse: nested.StudiListNested]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-modern/src/nested/StudiListNested.java"}
 
-### Statische innere Klassen ("_Static Nested Classes_")
+## Statische innere Klassen ("_Static Nested Classes_")
 
 *   Keine implizite Referenz auf Objekt
 *   Nur Zugriff auf Klassenmethoden und -attribute
@@ -263,7 +263,7 @@ Outer.StaticNested nested = new Outer.StaticNested();
 :::::::::
 
 
-## Lösung: Comparator als anonyme innere Klasse
+# Lösung: Comparator als anonyme innere Klasse
 
 ```java
 List<Studi> sl = new ArrayList<>();
@@ -294,7 +294,7 @@ sl.sort(
 [Demo: nested.DemoAnonymousInnerClass]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-modern/src/nested/DemoAnonymousInnerClass.java"}
 
 
-## Vereinfachung mit Lambda-Ausdruck
+# Vereinfachung mit Lambda-Ausdruck
 
 ```java
 List<Studi> sl = new ArrayList<>();
@@ -324,7 +324,7 @@ werden kann, muss der erwartete Parameter vom Typ her ein "**funktionales Interf
 [Demo: nested.DemoLambda]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-modern/src/nested/DemoLambda.java"}
 
 
-## Syntax für Lambdas
+# Syntax für Lambdas
 
 ```java
 (Studi o1, Studi o2)  ->  o1.getCredits() - o2.getCredits()
@@ -359,7 +359,7 @@ Varianten:
 *   **`(parameters)  ->  { statements; }`**
 
 
-## Quiz: Welches sind keine gültigen Lambda-Ausdrücke?
+# Quiz: Welches sind keine gültigen Lambda-Ausdrücke?
 
 1.  `() -> {}`
 2.  `() -> "wuppie"`
@@ -386,7 +386,7 @@ also `return "foo";` ...).
 ::::::
 
 
-## Definition "Funktionales Interface" ("_functional interfaces_")
+# Definition "Funktionales Interface" ("_functional interfaces_")
 
 ```java
 @FunctionalInterface
@@ -434,7 +434,7 @@ eigenen Projekten nutzen!
 :::
 
 
-## Quiz: Welches ist kein funktionales Interface?
+# Quiz: Welches ist kein funktionales Interface?
 
 ```java
 public interface Wuppie {
@@ -465,7 +465,7 @@ Auflösung:
 ::::::
 
 
-## Lambdas und funktionale Interfaces: Typprüfung
+# Lambdas und funktionale Interfaces: Typprüfung
 
 ```java
 interface java.util.Comparator<T> {
@@ -500,7 +500,7 @@ Der Compiler prüft in etwa folgende Schritte, wenn er über einen Lambda-Ausdru
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Anonyme Klassen: "Wegwerf"-Innere Klassen
     *   Müssen Interface implementieren oder Klasse erweitern

--- a/lecture/java-modern/methodreferences.md
+++ b/lecture/java-modern/methodreferences.md
@@ -114,7 +114,7 @@ challenges: |
 ---
 
 
-## Beispiel: Sortierung einer Liste
+# Beispiel: Sortierung einer Liste
 
 ```java
 List<Studi> sl = new ArrayList<Studi>();
@@ -135,7 +135,7 @@ Collections.sort(sl, Studi::cmpCpsClass);
 ```
 
 ::: notes
-### Anmerkung
+## Anmerkung
 
 Für das obige Beispiel wird davon ausgegangen, dass in der Klasse `Studi` eine
 statische Methode `cmpCpsClass()` existiert:
@@ -162,7 +162,7 @@ auch direkt per _Methoden-Referenz_ abkürzen!
 
 
 ::: notes
-## Überblick: Arten von Methoden-Referenzen
+# Überblick: Arten von Methoden-Referenzen
 
 1.  Referenz auf eine statische Methode
     *   Form: `ClassName::staticMethodName`
@@ -191,7 +191,7 @@ Interface mit entsprechend vielen Parametern definiert werden ...
 [[Hinweis: Klassen- vs. Instanz-Methoden]{.ex}]{.slides}
 
 
-## Methoden-Referenz 1: Referenz auf statische Methode
+# Methoden-Referenz 1: Referenz auf statische Methode
 
 ```java
 public class Studi {
@@ -225,7 +225,7 @@ aufgerufen.
 :::
 
 
-## Methoden-Referenz 2: Referenz auf Instanz-Methode (Objekt)
+# Methoden-Referenz 2: Referenz auf Instanz-Methode (Objekt)
 
 ```java
 public class Studi {
@@ -260,7 +260,7 @@ aufgerufen.
 :::
 
 
-## Methoden-Referenz 3: Referenz auf Instanz-Methode (Typ)
+# Methoden-Referenz 3: Referenz auf Instanz-Methode (Typ)
 
 ```java
 public class Studi {
@@ -293,7 +293,7 @@ aufgerufen.
 :::
 
 
-## Ausblick: Threads
+# Ausblick: Threads
 
 ::: notes
 Erinnerung an bzw. Vorgriff auf ["Threads: Intro"](../java-classic/threads-intro.md):
@@ -327,7 +327,7 @@ Thread t3 = new Thread(ThreadStarter::wuppie);
 [Beispiel: methodreferences.ThreadStarter]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-modern/src/methodreferences/ThreadStarter.java"}
 
 
-## Ausblick: Datenstrukturen als Streams
+# Ausblick: Datenstrukturen als Streams
 
 ::: notes
 Erinnerung an bzw. Vorgriff auf ["Stream-API"](stream-api.md):
@@ -364,7 +364,7 @@ List<Integer> wordLengths = words.stream()
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 Seit Java8: **Methoden-Referenzen** statt anonymer Klassen (**funktionales Interface nötig**)
 

--- a/lecture/java-modern/optional.md
+++ b/lecture/java-modern/optional.md
@@ -91,7 +91,7 @@ challenges: |
 ---
 
 
-## Motivation
+# Motivation
 
 ```java
 public class LSF {
@@ -123,7 +123,7 @@ public static void main(String... args) {
 ```
 
 ::: notes
-### Problem: `null` wird an (zu) vielen Stellen genutzt
+## Problem: `null` wird an (zu) vielen Stellen genutzt
 
 *   Es gibt keinen Wert ("not found")
 *   Felder wurden (noch) nicht initialisiert
@@ -132,14 +132,14 @@ public static void main(String... args) {
 => Parameter und Rückgabewerte müssen stets auf `null` geprüft werden
 (oder Annotationen wie `@NotNull` eingesetzt werden ...)
 
-### Lösung
+## Lösung
 
 *   `Optional<T>` für Rückgabewerte, die "kein Wert vorhanden" mit einschließen
     (statt `null` bei Abwesenheit von Werten)
 *   `@NotNull`/`@Nullable` für Parameter einsetzen (oder separate Prüfung)
 *   Exceptions werfen in Fällen, wo ein Problem aufgetreten ist
 
-### Anmerkungen
+## Anmerkungen
 
 *   Verwendung von `null` auf Attribut-Ebene (Klassen-interne Verwendung) ist okay!
 *   `Optional<T>` ist **kein** Ersatz für `null`-Checks!
@@ -147,7 +147,7 @@ public static void main(String... args) {
     Das häufig zu beobachtende "Irgendwas Unerwartetes ist passiert, hier ist `null`"
     ist ein **Anti-Pattern**!
 
-### Beispiel aus der Praxis im PM-Dungeon
+## Beispiel aus der Praxis im PM-Dungeon
 
 Schauen Sie sich einmal das Review zu den `ecs.components.ai.AITools` in
 https://github.com/Dungeon-CampusMinden/Dungeon/pull/128#pullrequestreview-1254025874
@@ -229,7 +229,7 @@ die nachfolgende Diskussion ergeben:
 :::
 
 
-## Erzeugen von _Optional_-Objekten
+# Erzeugen von _Optional_-Objekten
 
 Konstruktor ist `private` ...
 
@@ -254,7 +254,7 @@ Stattdessen sollte stets `Optional.ofNullable()` verwendet werden.
 [(Das wäre dann eben `Optional.empty()`.)]{.notes}
 
 
-## LSF liefert jetzt _Optional_ zurück
+# LSF liefert jetzt _Optional_ zurück
 
 ```java
 public class LSF {
@@ -287,7 +287,7 @@ kann.
 :::
 
 
-## Zugriff auf _Optional_-Objekte
+# Zugriff auf _Optional_-Objekte
 
 ::: notes
 In der funktionalen Programmierung gibt es schon lange das Konzept von `Optional`,
@@ -342,7 +342,7 @@ Aufruf möglicherweise in ein `try/catch` verpackt werden. Dito für `orElseThro
 :::
 
 
-## Einsatz mit Stream-API
+# Einsatz mit Stream-API
 
 ```java
 public class LSF {
@@ -390,7 +390,7 @@ ohne extra `null`-Prüfung - allerdings will man noch ein Exception-Handling ein
 
 
 ::: notes
-## Weitere _Optionals_
+# Weitere _Optionals_
 
 Für die drei primitiven Datentypen `int`, `long` und `double` gibt es passende
 Wrapper-Klassen von `Optional<T>`: `OptionalInt`, `OptionalLong` und `OptionalDouble`.
@@ -401,7 +401,7 @@ Werte - diese können nicht `null` sein.
 :::
 
 
-## Regeln für _Optional_
+# Regeln für _Optional_
 
 1.  Nutze `Optional` nur als Rückgabe für "kein Wert vorhanden"
 
@@ -473,7 +473,7 @@ Werte - diese können nicht `null` sein.
 
 
 ::: notes
-## Interessante Links
+# Interessante Links
 
 *   ["Using Optionals"](https://dev.java/learn/api/streams/optionals/)
 *   ["What You Might Not Know About Optional"](https://medium.com/javarevisited/what-you-might-not-know-about-optional-7238e3c05f63)
@@ -483,7 +483,7 @@ Werte - diese können nicht `null` sein.
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 `Optional` als Rückgabe für "kein Wert vorhanden"
 

--- a/lecture/java-modern/records.md
+++ b/lecture/java-modern/records.md
@@ -96,7 +96,7 @@ challenges: |
 ---
 
 
-## Motivation; Klasse Studi
+# Motivation; Klasse Studi
 
 ```java
 public class Studi {
@@ -119,7 +119,7 @@ public class Studi {
 ```
 
 
-## Klasse Studi als Record
+# Klasse Studi als Record
 
 ```java
 public record StudiR(String name, int credits) {}
@@ -154,7 +154,7 @@ entsprechen denen der Komponenten, es fehlt also der übliche "get"-Präfix!
 :::
 
 
-## Eigenschaften und Einschränkungen von Record-Klassen
+# Eigenschaften und Einschränkungen von Record-Klassen
 
 *   Records erweitern implizit die Klasse `java.lang.Record`: \newline
     Keine andere Klassen mehr erweiterbar! (Interfaces kein Problem)
@@ -168,7 +168,7 @@ entsprechen denen der Komponenten, es fehlt also der übliche "get"-Präfix!
 *   Statische Attribute mit Initialisierung erlaubt
 
 
-## Records: Prüfungen im Konstruktor
+# Records: Prüfungen im Konstruktor
 
 ::: notes
 Der Konstruktor ist erweiterbar:
@@ -219,7 +219,7 @@ public StudiT() {
 :::
 
 
-## Getter und Methoden
+# Getter und Methoden
 
 ::: notes
 Getter werden vom Compiler automatisch generiert. Dabei entsprechen die Methoden-Namen
@@ -255,7 +255,7 @@ geändert werden!
 
 
 ::: notes
-## Beispiel aus den Challenges
+# Beispiel aus den Challenges
 
 In den Challenges zum Thema Optional gibt es die Klasse `Katze` in den
 [Vorgaben](https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/java-modern/src/challenges/optional/Katze.java).
@@ -274,7 +274,7 @@ wurde die Les- und Wartbarkeit deutlich verbessert.
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Records sind immutable Klassen:
     *   `final` Attribute (entsprechend den Komponenten)

--- a/lecture/java-modern/stream-api.md
+++ b/lecture/java-modern/stream-api.md
@@ -113,7 +113,7 @@ challenges: |
 ---
 
 
-## Motivation
+# Motivation
 
 ::: notes
 Es wurden Studis, Studiengänge und Fachbereiche modelliert (aus Gründen der Übersichtlichkeit
@@ -147,7 +147,7 @@ realisiert ist. (Inhaltlich ist es vermutlich nicht sooo sinnvoll.)
 :::
 
 
-## Innere Schleife mit Streams umgeschrieben
+# Innere Schleife mit Streams umgeschrieben
 
 ```java
 private static long getCountSG(Studiengang sg) {
@@ -167,7 +167,7 @@ private static long getCountFB2(Fachbereich fb) {
 ```
 
 ::::::::: notes
-### Erklärung des Beispiels
+## Erklärung des Beispiels
 
 Im Beispiel wurde die innere Schleife in einen Stream ausgelagert.
 
@@ -180,7 +180,7 @@ alle Elemente aus dem Strom entfernt, die der Bedingung nicht
 entsprechen. Am Ende wird mit `count()` gezählt, wie viele Elemente
 im Strom enthalten sind.
 
-### Was ist ein Stream?
+## Was ist ein Stream?
 
 Ein "Stream" ist ein Strom (Folge) von Daten oder Objekten. In Java wird
 die Collections-API für die Speicherung von Daten (Objekten) verwendet.
@@ -221,7 +221,7 @@ Operationen dürfen auf keinen Fall die Datenquelle des Streams modifizieren!
 :::::::::
 
 
-## Erzeugen von Streams
+# Erzeugen von Streams
 
 ```java
 List<String> l1 = List.of("Hello", "World", "foo", "bar", "wuppie");
@@ -262,7 +262,7 @@ erwarten sind (Overhead!).
 :::
 
 
-## Intermediäre Operationen auf Streams
+# Intermediäre Operationen auf Streams
 
 ```java
 private static void dummy(Studiengang sg) {
@@ -322,7 +322,7 @@ Operationen und schließt den Stream ab.
 :::
 
 
-## Was tun, wenn eine Methode Streams zurückliefert
+# Was tun, wenn eine Methode Streams zurückliefert
 
 ::: notes
 Wir konnten vorhin nur die innere Schleife in eine Stream-basierte Verarbeitung
@@ -390,7 +390,7 @@ private static long getCountFB(Fachbereich fb) {
 :::
 
 
-## Streams abschließen: Terminale Operationen
+# Streams abschließen: Terminale Operationen
 
 ```java
 Stream<String> s = Stream.of("Hello", "World", "foo", "bar", "wuppie");
@@ -437,7 +437,7 @@ bei den intermediären als auch den terminalen Operationen. Schauen Sie in die D
 :::
 
 
-## Spielregeln
+# Spielregeln
 
 *   Operationen dürfen nicht die Stream-Quelle modifizieren
 
@@ -451,7 +451,7 @@ bei den intermediären als auch den terminalen Operationen. Schauen Sie in die D
     [(dies verhindert u.U. die parallele Verarbeitung)]{.notes}
 
 
-## Wrap-Up
+# Wrap-Up
 
 `Stream<T>`: Folge von Objekten vom Typ `T`, Verarbeitung "lazy"
 [(Gegenstück zu `Collection<T>`: Dort werden Daten **gespeichert**, hier werden Daten **verarbeitet**)]{.notes}

--- a/lecture/misc/dungeon.md
+++ b/lecture/misc/dungeon.md
@@ -61,7 +61,7 @@ attachments:
 Dieses Dokument ist nicht für die Nutzung als Foliensatz vorbereitet.
 -->
 
-## How-To Dungeon
+# How-To Dungeon
 
 In diesem Semester werden Sie im Praktikum schrittweise Erweiterungen in verschiedenen
 "fertigen" Rogue-like Computerspielen programmieren und dabei (hoffentlich) die Methoden aus
@@ -75,7 +75,7 @@ Wir werden uns in diesem How-To einen Überblick verschaffen und einen ersten Ei
 versuchen: Wir programmieren einen einfachen Helden.
 
 
-## Projekt PM-Dungeon
+# Projekt PM-Dungeon
 
 Das Projekt PM-Dungeon entstand in verschiedenen Forschungsprojekten und wurde (und wird)
 aktiv von Studierenden und wissenschaftlichen Mitarbeitern am Campus Minden entwickelt.
@@ -94,7 +94,7 @@ von Klassen und Methoden, sinnvolles Javadoc, Dokumentation jenseits des Javadoc
 Commit-Messages und PR-Summaries.
 
 
-## Installation des Frameworks
+# Installation des Frameworks
 
 Sie finden das Projekt auf GitHub:
 [github.com/Dungeon-CampusMinden/Dungeon](https://github.com/Dungeon-CampusMinden/Dungeon).
@@ -116,7 +116,7 @@ Sonderzeichen (Umlaute o.ä.) vorkommen! Dies kann zu seltsamen Fehler führen. 
 darauf achten, dass Sie als JDK ein **Java SE 21 (LTS)** verwenden.
 
 
-## Java: Java SE 21 (LTS)
+# Java: Java SE 21 (LTS)
 
 Wir benutzen im Dungeon-Projekt die aktuelle LTS-Version des JDK, d.h. **Java SE 21 (LTS)**.
 Sie können sich das JDK bei [Oracle](https://www.oracle.com/java/technologies/downloads/)
@@ -138,7 +138,7 @@ ungefähr diese Ausgabe erzeugen (ignorieren Sie die Minor-Version, wichtig ist 
     Java HotSpot(TM) 64-Bit Server VM (build 21.0.3+7-LTS-152, mixed mode, sharing)
 
 
-## Erster Test
+# Erster Test
 
 Für einen ersten Test gehen Sie in der Konsole in den vorhin erzeugten neuen Ordner
 `pm-dungeon/` und führen Sie dort den Befehl
@@ -157,7 +157,7 @@ Dies dauert je nach Internetanbindung etwas - beim nächsten Start geht es dann 
 schneller, weil ja bereits alles da ist.
 
 
-## Import in der IDE
+# Import in der IDE
 
 Importieren Sie das Projekt als Gradle-basiertes Projekt, dann übernimmt die IDE die
 Konfiguration für Sie.
@@ -170,7 +170,7 @@ Konfiguration für Sie.
 starten, und es erscheint wieder ein minimales Level.
 
 
-## Überblick über die (Sub-) Projekte
+# Überblick über die (Sub-) Projekte
 
 Sie finden im Package-Explorer eine Reihe von Unterprojekten (Gradle-Subprojekte). Für PR2
 ist eigentlich nur das Subprojekt
@@ -210,7 +210,7 @@ anschauen sollten. Zusätzlich gibt es für Game und Dungeon noch weitere Dokume
 `doc/`-Ordnern.
 
 
-## Überblick über die Java-Strukturen
+# Überblick über die Java-Strukturen
 
 ![](https://github.com/Dungeon-CampusMinden/Dungeon/blob/master/game/doc/img/gameloop.png?raw=true)
 
@@ -248,7 +248,7 @@ Dungeon"](https://github.com/Dungeon-CampusMinden/Dungeon/blob/master/game/doc/q
 eine gute Anleitung, die auf die Strukturen tiefer eingeht.
 
 
-## Mein Held
+# Mein Held
 
 Um einen besseren Blick in das System zu bekommen, erstellen wir schrittweise einen eigenen
 einfachen Helden.
@@ -281,7 +281,7 @@ tasks.register('run', JavaExec) {
 ```
 
 
-## Einschub: ECS oder Entities, Components und Systems
+# Einschub: ECS oder Entities, Components und Systems
 
 Der Held ist ein Element im Spiel. Diese Struktur muss geeignet modelliert werden.
 
@@ -293,7 +293,7 @@ Vorbildern" wie beispielsweise
 Neben verschiedenen Hilfsstrukturen gibt es dabei nur **Entitäten**, **Komponenten** und
 **Systeme**. Hier werden sämtliche Informationen und Verhalten modelliert.
 
-### Entity
+## Entity
 
 Die Idee dahinter ist: Alle Elemente im Spiel werden als *Entität* realisiert, d.h. der Held
 und die Monster und die Items, die man so finden kann, sind alles Entitäten. Sogar Feuerbälle
@@ -308,7 +308,7 @@ registriert werden. Man kann die Entitäten über die API abrufen (`Game#allEnti
 
 Unsere Basisklasse für Entitäten ist aktuell `core.Entity`.
 
-### Component
+## Component
 
 Components bündeln bestimmte Werte einer Entität für bestimmte Zwecke, d.h. statt der
 Attribute in einer Klasse (Entität) nutzen wir hier eine weitere Kapselung.
@@ -329,7 +329,7 @@ Components speichern vor allem Werte und haben nur in Ausnahmefällen eigenes Ve
 
 Das Basisinterface für Components ist derzeit `core.Component`.
 
-### System
+## System
 
 Mit Entitäten und passenden Components, über die wir die Eigenschaften ausdrücken, können wir
 bereits Spielelemente im Dungeon repräsentieren.
@@ -353,9 +353,9 @@ Basisklasse ist derzeit `core.System` - falls Sie einmal eigene Systeme implemen
 Doku](https://github.com/Dungeon-CampusMinden/Dungeon/blob/master/game/doc/create_own_content.md))
 
 
-## Nun aber Helden!
+# Nun aber Helden!
 
-### Ein Held ist eine Entität
+## Ein Held ist eine Entität
 
 Also legen wir nun endlich einen neuen Helden als Instanz von `core.Entity` an und
 registrieren diese Entität im Spiel:
@@ -386,7 +386,7 @@ Prinzipiell haben Sie damit alles, um das Spiel starten zu können. In der Praxi
 aber keinen Helden: Der hat nämlich weder eine Position noch eine Textur, kann also gar nicht
 angezeigt werden.
 
-### Wo bin ich grad?
+## Wo bin ich grad?
 
 Der Held braucht eine Position. Dazu gibt es `core.components.PositionComponent`. Fügen wir
 diese einfach dem Helden hinzu:
@@ -426,7 +426,7 @@ ist).
 
 Wenn Sie jetzt das Spiel starten, sehen Sie - immer noch nichts (außer den Wänden). Hmmm.
 
-### Animateure
+## Animateure
 
 Um den Held zeichnen zu können, brauchen wir eine Animation - also eine `DrawComponent`.
 
@@ -482,7 +482,7 @@ gleich noch eine `PlayerComponent`.
 
 Jetzt wackelt der Held auf der Stelle herum ...
 
-### Bewege mich
+## Bewege mich
 
 Für die Bewegung ist das `VelocitySystem` zuständig. Dieses fragt in allen Entitäten die
 `VelocityComponent` sowie die `PositionComponent` ab, berechnet die nächste neue Position und
@@ -569,9 +569,9 @@ Nun sollten Sie Ihren Helden (nach oben) bewegen können. (Tipp: Probieren Sie "
 diejenigen Entitäten, die alle benötigten Components aufweisen.
 
 
-## Walking mit System
+# Walking mit System
 
-### Neue Monster
+## Neue Monster
 
 Wie kann ich ein Monster beim Laden des Levels erzeugen?
 
@@ -633,7 +633,7 @@ und dann "ewig" laufen, insbesondere bei Reaktion auf Tastatureingaben. Deshalb 
 Entitäten kurz bewegt und bremsen dann wieder ab. Das Aufrechterhalten der Bewegung erfolgt
 normalerweise über Systeme ...
 
-### Systems für das selbstständige Laufen
+## Systems für das selbstständige Laufen
 
 Wir brauchen ein System, welches die aktuelle Geschwindigkeit einer Entität in jedem Frame
 wieder auf den alten Wert setzt. Dazu leiten wir von `core.System` ab. (Achtung: Es gibt auch
@@ -683,7 +683,7 @@ Nun läuft das neue Monster los (bis es gegen eine Wand läuft).
 
 Aber der Held bewegt sich nun ebenfalls dauerhaft :(
 
-### Components für das selbstständige Laufen
+## Components für das selbstständige Laufen
 
 Das Problem ist, dass unser neues `WalkerSystem` **alle** Entitäten automatisch bewegt. (Ein
 weiteres Problem ist, dass das `WalkerSystem` davon ausgeht, dass es immer eine
@@ -766,7 +766,7 @@ Tatsächlich gibt es im Sub-Projekt "dungeon" (Package `contrib`) bereits eine V
 Components und passenden Systems, die solche typischen Aufgaben bereits realisieren.
 
 
-## Kämpfe wie ein NPC
+# Kämpfe wie ein NPC
 
 Wir haben beim Hero über das `PlayerComponent` eine Reaktion auf Tastatureingaben
 implementiert. Hier könnte man einer Taste auch den Start einer neuen Entität zuordnen, die
@@ -847,7 +847,7 @@ All diese (und viele weitere) Components und Systems gibt es bereits im Package 
 Sub-Projekt ["dungeon"](https://github.com/Dungeon-CampusMinden/Dungeon/tree/master/dungeon).
 
 
-## Wrap-Up
+# Wrap-Up
 
 ::: notes
 Damit endet der kurze Ausflug in den Dungeon.

--- a/lecture/misc/intro-frameworks.md
+++ b/lecture/misc/intro-frameworks.md
@@ -24,12 +24,12 @@ fhmedia:
 ---
 
 
-## Checkliste für die Entwicklung eines simplen Videospiels
+# Checkliste für die Entwicklung eines simplen Videospiels
 
 ![](images/checklisteMotivation.png){width="60%"}
 
 
-## Checkliste für die Entwicklung eines simplen Videospiels mit Framework
+# Checkliste für die Entwicklung eines simplen Videospiels mit Framework
 
 ![](images/checklisteMotivationFarbig.png){width="60%"}
 
@@ -47,7 +47,7 @@ werden, die Anfragen annimmt, bearbeitet und die Antworten wieder zurückliefert
 :::
 
 
-## Was sind Frameworks?
+# Was sind Frameworks?
 
 ::: notes
 Frameworks liefern die Rahmenstruktur und Architektur, um Programme für die
@@ -62,7 +62,7 @@ zu implementieren, sind dabei aber selbst keine eigenen Programme (vgl. PM-Dunge
 :::
 
 ::: notes
-## Unterschied zu Libraries
+# Unterschied zu Libraries
 
 *   Libraries stellen Funktionen bereit, die frei in der eigenen Implementierung
     genutzt werden können.
@@ -84,7 +84,7 @@ zu implementieren, sind dabei aber selbst keine eigenen Programme (vgl. PM-Dunge
 ![](images/frameworksVSlib.png){width="80%"}
 
 
-## Verbreitete Frameworks
+# Verbreitete Frameworks
 
 | Framework | Anwendungszweck                                  |
 |-----------|--------------------------------------------------|
@@ -95,9 +95,9 @@ zu implementieren, sind dabei aber selbst keine eigenen Programme (vgl. PM-Dunge
 | libGDX    | Game Development  :)                             |
 
 
-## Mögliche Vor- und Nachteile von Frameworks
+# Mögliche Vor- und Nachteile von Frameworks
 
-### (+) Vorteile
+## (+) Vorteile
 
 *   Ermöglichen eine schnelle Implementierung umfangreicher Softwarekonstrukte
 *   Verstecken komplexe Zusammenhänge vor den Entwicklern
@@ -106,7 +106,7 @@ zu implementieren, sind dabei aber selbst keine eigenen Programme (vgl. PM-Dunge
 
 \bigskip
 
-### (-) Nachteile
+## (-) Nachteile
 
 *   Oftmals sehr umfangreich und schwer zu erlernen
 *   Fokus oft nicht mehr nur auf einem Anwendungsbereich (z.B. Spring)
@@ -117,14 +117,14 @@ zu implementieren, sind dabei aber selbst keine eigenen Programme (vgl. PM-Dunge
 
 
 ::: notes
-## Frameworks finden
+# Frameworks finden
 
-### Wann sollte man Frameworks verwenden?
+## Wann sollte man Frameworks verwenden?
 
 Wenn man bereits etablierte Anwendungen (wie Webservices) mit eigener
 Funktionalität anbieten möchte.
 
-### Wie/Wo findet man passende Frameworks?
+## Wie/Wo findet man passende Frameworks?
 
 *   Internetrecherche
 *   Foren
@@ -132,7 +132,7 @@ Funktionalität anbieten möchte.
 :::
 
 
-## Wie starte ich mit einem Framework?
+# Wie starte ich mit einem Framework?
 
 ::: notes
 Beispielproblem: Es soll eine interne Webanwendung bereitgestellt werden, die
@@ -161,7 +161,7 @@ ist ein einfaches und schlankes Framework zu bevorzugen.
 [Demo: Web-Anwendung für Zufallszahlen]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/tree/master/lecture/misc/src/javalin/"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Frameworks stellen einen Rahmen und eine Architektur für wiederkehrende
     Softwarestrukturen bereit

--- a/lecture/pattern/command.md
+++ b/lecture/pattern/command.md
@@ -57,7 +57,7 @@ challenges: |
 ---
 
 
-## Motivation
+# Motivation
 
 ::: notes
 Irgendwo im Dungeon wird es ein Objekt einer Klasse ähnlich wie `InputHandler`
@@ -89,7 +89,7 @@ zugeordnet und erlauben keinerlei Konfiguration.
 [[Problem: Starre Zuordnung]{.ex}]{.slides}
 
 
-## Auflösen der starren Zuordnung über Zwischenobjekte
+# Auflösen der starren Zuordnung über Zwischenobjekte
 
 ```java
 public interface Command { void execute(); }
@@ -132,7 +132,7 @@ Beispiel oben wurde dafür der `hero` genutzt.
 :::
 
 
-## Command: Objektorientierte Antwort auf Callback-Funktionen
+# Command: Objektorientierte Antwort auf Callback-Funktionen
 
 ![](images/command.png){web_width="80%"}
 
@@ -167,7 +167,7 @@ In unserem Beispiel lassen sich die einzelnen Teile so sortieren:
 :::
 
 
-## Undo
+# Undo
 
 ::: notes
 Wir könnten das `Command`-Interface um ein paar Methoden erweitern:
@@ -230,7 +230,7 @@ keine weitere Buchhaltung ...
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 **Command-Pattern**: Kapsele Befehle in ein Objekt
 

--- a/lecture/pattern/factory-method.md
+++ b/lecture/pattern/factory-method.md
@@ -78,7 +78,7 @@ challenges: |
 ---
 
 
-## Motivation: Ticket-App
+# Motivation: Ticket-App
 
 *   Nutzer geben Fahrtziel an (und nicht die Ticketart!)
 
@@ -94,12 +94,12 @@ challenges: |
 => **Factory-Method-Pattern**: Objekte sollen nicht direkt durch den Nutzer erzeugt werden
 
 
-## Factory-Method-Pattern
+# Factory-Method-Pattern
 
 ![](images/factorymethod.png){width="80%"}
 
 
-## Hands-On: Ticket-App
+# Hands-On: Ticket-App
 
 Implementieren Sie eine Ticket-App, die verschiedene Tickets mit
 Hilfe des Factory-Method Entwurfsmusters generiert.
@@ -107,7 +107,7 @@ Hilfe des Factory-Method Entwurfsmusters generiert.
 [UML; Konsole: factory.FactoryBeispiel]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/pattern/src/factory/FactoryBeispiel.java"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Konkrete Objekte sollen nicht direkt über Konstruktor erzeugt werden
 *   (Statische) Hilfsmethode, die aus Parameter das "richtige" Objekte erzeugt

--- a/lecture/pattern/flyweight.md
+++ b/lecture/pattern/flyweight.md
@@ -42,10 +42,10 @@ challenges: |
 ---
 
 
-## Motivation: Modellierung eines Levels
+# Motivation: Modellierung eines Levels
 
 ::: notes
-### Variante I: Einsatz eines Enums für die Felder
+## Variante I: Einsatz eines Enums für die Felder
 :::
 
 ```java
@@ -84,11 +84,11 @@ müssen _alle_ `switch/case`-Blöcke entsprechend angepasst werden.
 
 
 ::: slides
-## Motivation: Modellierung eines Levels (cnt.)
+# Motivation: Modellierung eines Levels (cnt.)
 :::
 
 ::: notes
-### Variante II: Einsatz einer Klasse/Klassenhierarchie für die Felder
+## Variante II: Einsatz einer Klasse/Klassenhierarchie für die Felder
 :::
 
 ```java
@@ -124,7 +124,7 @@ geladen und entsprechend mehrfach im Speicher gehalten (großer Speicherbedarf).
 :::
 
 
-## Flyweight: Nutze gemeinsame Eigenschaften gemeinsam
+# Flyweight: Nutze gemeinsame Eigenschaften gemeinsam
 
 ::: notes
 Idee: Eigenschaften, die nicht an einem konkreten Objekt hängen, werden in gemeinsam genutzte
@@ -133,7 +133,7 @@ Objekte ausgelagert (Shared Objects/Memory).
 Ziel: Erhöhung der Speichereffizienz (geringerer Bedarf an Hauptspeicher, geringere Bandbreite
 bei der Übertragung der Daten/Objekt an die GPU, ...).
 
-### Lösungsvorschlag I
+## Lösungsvorschlag I
 :::
 
 ```java
@@ -171,11 +171,11 @@ wie etwa, ob ein Feld bereits durch den Helden untersucht/betreten wurde o.ä. .
 
 
 ::: slides
-## Flyweight: Nutze gemeinsame Eigenschaften gemeinsam (cnt.)
+# Flyweight: Nutze gemeinsame Eigenschaften gemeinsam (cnt.)
 :::
 
 ::: notes
-### Lösungsvorschlag II
+## Lösungsvorschlag II
 :::
 
 ```java
@@ -220,7 +220,7 @@ je einmal im Speicher repräsentiert.
 :::
 
 
-## Flyweight-Pattern: Begriffe
+# Flyweight-Pattern: Begriffe
 
 *   **Intrinsic** State: invariant, Kontext-unabhängig, gemeinsam nutzbar \newline
     => auslagern in gemeinsame Objekte
@@ -231,7 +231,7 @@ je einmal im Speicher repräsentiert.
     => individuell modellieren
 
 
-## Flyweight-Pattern: Klassische Modellierung
+# Flyweight-Pattern: Klassische Modellierung
 
 ![](images/flyweight.png){width="60%"}
 
@@ -254,7 +254,7 @@ Zusätzlich gibt es Klassen, die extrinsischen Zustand modellieren und deshalb n
 Nutzern geteilt werden können und deren Objekte bei jeder Anfrage neu erstellt werden. Aber
 auch diese werden von der Factory erzeugt/verwaltet.
 
-### Kombination mit dem Composite-Pattern
+## Kombination mit dem Composite-Pattern
 
 In der Praxis kann man das Pattern so direkt meist nicht einsetzen, sondern verbindet es mit
 dem Composite-Pattern:
@@ -266,7 +266,7 @@ oder eine zusammengesetzte Komponente, die ihrerseits andere Komponenten speiche
 Beispiel war das die Klasse `Tile`, die ein Objekt vom Typ `TileModel` referenziert - allerdings
 fehlt im obigen Beispiel das gemeinsame Interface ...).
 
-### Level-Beispiel mit Flyweight (vollständig) und Composite
+## Level-Beispiel mit Flyweight (vollständig) und Composite
 
 Im obigen Beispiel wurde zum Flyweight-Pattern noch das Composite-Pattern hinzugenommen, aber
 es wurde aus Gründen der Übersichtlichkeit auf ein gemeinsames Interface und auf die Factory
@@ -336,7 +336,7 @@ public class Level {
 
 
 ::: notes
-## Verwandtschaft zum Type-Object-Pattern
+# Verwandtschaft zum Type-Object-Pattern
 
 Das [Flyweight-Pattern](https://gameprogrammingpatterns.com/flyweight.html) ist sehr ähnlich zum
 [Type-Object-Pattern](type-object.md). In beiden Pattern teilen
@@ -351,7 +351,7 @@ werden. Die Zielrichtung unterscheidet sich aber deutlich:
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 Flyweight-Pattern: Steigerung der (Speicher-) Effizienz durch gemeinsame Nutzung von Objekten
 

--- a/lecture/pattern/observer.md
+++ b/lecture/pattern/observer.md
@@ -90,7 +90,7 @@ challenges: |
 ---
 
 
-## Verteilung der Prüfungsergebnisse
+# Verteilung der Prüfungsergebnisse
 
 ![](images/lsf.png){width="80%"}
 
@@ -117,7 +117,7 @@ for (Person p : persons) {
 :::
 
 
-## Elegantere Lösung: Observer-Entwurfsmuster
+# Elegantere Lösung: Observer-Entwurfsmuster
 
 ![](images/observerexample.png){width="80%"}
 
@@ -132,7 +132,7 @@ die traditionell `update()` genannt wird.
 [Demo: observer]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/tree/master/lecture/pattern/src/observer/"}
 
 
-## Observer-Pattern verallgemeinert
+# Observer-Pattern verallgemeinert
 
 ![](images/observer.png){width="80%"}
 
@@ -165,7 +165,7 @@ sondern implementieren Ihre eigenen Interfaces, wenn Sie das Observer-Pattern ei
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 Observer-Pattern: Benachrichtige registrierte Objekte über Statusänderungen
 

--- a/lecture/pattern/singleton.md
+++ b/lecture/pattern/singleton.md
@@ -29,7 +29,7 @@ fhmedia:
 ---
 
 
-## Motivation
+# Motivation
 
 ```java
 public enum Fach { IFM, ELM, ARC }
@@ -55,7 +55,7 @@ Beispiel für das Singleton-Pattern ...
 :::
 
 
-## Umsetzung: "Eager" Singleton Pattern
+# Umsetzung: "Eager" Singleton Pattern
 
 ::: notes
 Damit man von "außen" keine Instanzen einer Klasse anlegen kann, versteckt man den Konstruktor,
@@ -84,7 +84,7 @@ public class SingletonEager {
 [Beispiel: singleton.SingletonEager]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/pattern/src/singleton/SingletonEager.java"}
 
 
-## Umsetzung: "Lazy" Singleton Pattern
+# Umsetzung: "Lazy" Singleton Pattern
 
 ::: notes
 Beim "Lazy Singleton Pattern" wird das Objekt erst erzeugt, wenn die Instanz tatsächlich benötigt
@@ -113,7 +113,7 @@ public class SingletonLazy {
 [Beispiel: singleton.SingletonLazy]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/pattern/src/singleton/SingletonLazy.java"}
 
 
-## Vorsicht!
+# Vorsicht!
 
 ::: center
 Sie schaffen damit eine globale Variable!
@@ -129,7 +129,7 @@ Nutzen Sie das Pattern **sparsam**.
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 Singleton-Pattern: Klasse, von der nur genau ein Objekt instantiiert werden kann
 

--- a/lecture/pattern/strategy.md
+++ b/lecture/pattern/strategy.md
@@ -60,7 +60,7 @@ challenges: |
 ---
 
 
-## Wie kann man das Verhalten einer Klasse dynamisch ändern?
+# Wie kann man das Verhalten einer Klasse dynamisch ändern?
 
 ![](images/hunde.png){width="60%"}
 
@@ -77,7 +77,7 @@ auch konkrete Bulldoggen geben mag, die nur leise fiepen ...
 :::
 
 
-## Lösung: Delegation der Aufgabe an geeignetes Objekt
+# Lösung: Delegation der Aufgabe an geeignetes Objekt
 
 ![](images/hunde_strat.png){width="80%"}
 
@@ -109,7 +109,7 @@ Entwurfsmuster: **Strategy Pattern**
 
 
 ::: notes
-## Exkurs UML: Assoziation vs. Aggregation vs. Komposition
+# Exkurs UML: Assoziation vs. Aggregation vs. Komposition
 
 Eine **Assoziation** beschreibt eine Beziehung zwischen zwei (oder mehr)
 UML-Elementen (etwa Klassen oder Interfaces).
@@ -135,7 +135,7 @@ und [Klassendiagramm](https://de.wikipedia.org/wiki/Klassendiagramm).
 
 
 ::: notes
-## Zweites Beispiel: Sortieren einer Liste von Studis
+# Zweites Beispiel: Sortieren einer Liste von Studis
 
 Sortieren einer Liste von Studis: `Collections.sort` kann eine Liste
 nach einem Default-Kriterium sortieren oder aber über einen extra
@@ -169,7 +169,7 @@ unsicher sind!
 :::
 
 
-## Hands-On: Strategie-Muster
+# Hands-On: Strategie-Muster
 
 Implementieren Sie das Strategie-Muster für eine Übersetzungsfunktion:
 
@@ -190,7 +190,7 @@ Implementieren Sie das Strategie-Muster für eine Übersetzungsfunktion:
 
 
 ::: notes
-## Auflösung
+# Auflösung
 
 ![](images/translator.png){width="80%"}
 :::
@@ -198,7 +198,7 @@ Implementieren Sie das Strategie-Muster für eine Übersetzungsfunktion:
 [Konsole strategy.TranslatorExample]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/pattern/src/strategy/TranslatorExample.java"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 Strategy-Pattern: Verhaltensänderung durch Delegation an passendes Objekt
 

--- a/lecture/pattern/template-method.md
+++ b/lecture/pattern/template-method.md
@@ -57,7 +57,7 @@ challenges: |
 ---
 
 
-## Motivation: Syntax-Highlighting im Tokenizer
+# Motivation: Syntax-Highlighting im Tokenizer
 
 ::: notes
 In einem Compiler ist meist der erste Arbeitsschritt, den Eingabestrom in einzelne
@@ -104,7 +104,7 @@ der Liste `allToken` auf den aktuellen Anfang des Eingabestroms passt.
 :::
 
 
-## Token-Klassen mit formatiertem Inhalt
+# Token-Klassen mit formatiertem Inhalt
 
 ::: notes
 Um den eigenen Tokenizer besser testen zu können, wurde beschlossen, dass jedes Token
@@ -151,7 +151,7 @@ von DRY aus ...
 :::
 
 
-## Don't call us, we'll call you
+# Don't call us, we'll call you
 
 ```java
 public abstract class Token {
@@ -203,12 +203,12 @@ Dies ist ein Beispiel für das **[Template-Method-Pattern](https://en.wikipedia.
 :::
 
 
-## Template-Method-Pattern
+# Template-Method-Pattern
 
 ![](images/template-method.png){width="80%" web_width="50%"}
 
 ::: notes
-### Aufbau Template-Method-Pattern
+## Aufbau Template-Method-Pattern
 
 In der Basisklasse implementiert man eine Template-Methode (in der Skizze `templateMethod`),
 die sich auf anderen in der Basisklasse deklarierten (Hilfs-) Methoden "abstützt" (diese also
@@ -221,7 +221,7 @@ Verhalten so neu formulieren (in der Skizze `method3`).
 
 Damit werden Teile des Verhaltens an die ableitenden Klassen ausgelagert.
 
-### Verwandtschaft zum Strategy-Pattern
+## Verwandtschaft zum Strategy-Pattern
 
 Das Template-Method-Pattern hat eine starke Verwandtschaft zum Strategy-Pattern.
 
@@ -238,7 +238,7 @@ im Template-Method-Pattern gewissermaßen nur Teile des Verhaltens an die ableit
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 Template-Method-Pattern: Verhaltensänderung durch Vererbungsbeziehungen
 

--- a/lecture/pattern/type-object.md
+++ b/lecture/pattern/type-object.md
@@ -66,7 +66,7 @@ challenges: |
 ---
 
 
-## Motivation: Monster und spezialisierte Monster
+# Motivation: Monster und spezialisierte Monster
 
 ```java
 public abstract class Monster {
@@ -115,7 +115,7 @@ Konstruktor aufrufen.
 :::
 
 
-## Vereinfachen der Vererbungshierarchie (mit Enums als Type-Object)
+# Vereinfachen der Vererbungshierarchie (mit Enums als Type-Object)
 
 ```java
 public enum Species { RAT, GNOLL, ... }
@@ -160,7 +160,7 @@ muss man bei Erweiterungen des Enums auch _alle_ `switch/case`-Blöcke anpassen.
 :::
 
 
-## Monster mit Strategie
+# Monster mit Strategie
 
 ```java
 public final class Species {
@@ -206,7 +206,7 @@ Code, vermutlich `main()` oder beispielsweise durch Einlesen einer Konfig-Datei)
 :::
 
 
-## Fabrikmethode für die Type-Objects
+# Fabrikmethode für die Type-Objects
 
 ```java
 public final class Species {
@@ -235,7 +235,7 @@ einbauen, über die dann die Monster erzeugt werden.
 :::
 
 
-## Vererbung unter den Type-Objects
+# Vererbung unter den Type-Objects
 
 ```java
 public final class Species {
@@ -273,7 +273,7 @@ aus dem Eltern-Type-Object übernommen (sofern dieses übergeben wird).
 :::
 
 
-## Erzeugen der Type-Objects dynamisch über eine Konfiguration
+# Erzeugen der Type-Objects dynamisch über eine Konfiguration
 
 ```json
 {
@@ -303,14 +303,14 @@ erzeugt.
 
 
 ::: notes
-## Vor- und Nachteile des Type-Object-Pattern
+# Vor- und Nachteile des Type-Object-Pattern
 
-### Vorteil
+## Vorteil
 
 Es gibt nur noch wenige Klassen auf Code-Ebene (im Beispiel: 2), und man kann über die
 Konfiguration beliebig viele Monster-Typen erzeugen.
 
-### Nachteil
+## Nachteil
 
 Es werden zunächst nur Daten "überschrieben", d.h. man kann nur für die einzelnen Typen
 spezifische Werte mitgeben/definieren.
@@ -320,7 +320,7 @@ Bei Vererbung kann man in den Unterklassen nahezu beliebig das Verhalten durch e
 dem man beispielsweise eine Reihe von vordefinierten Verhaltensarten implementiert, die
 dann anhand von Werten ausgewählt und anhand anderer Werte weiter parametrisiert werden.
 
-### Verwandtschaft zum Flyweight-Pattern
+## Verwandtschaft zum Flyweight-Pattern
 
 Das [Type-Object-Pattern](https://gameprogrammingpatterns.com/type-object.html) ist keines
 der ["klassischen" Design-Pattern](https://en.wikipedia.org/wiki/Design_Patterns) der "Gang
@@ -338,7 +338,7 @@ gemeinsame Hilfsobjekte eingebunden werden. Die Zielrichtung unterscheidet sich 
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 Type-Object-Pattern: Implementierung eines eigenen Objekt-Modells
 

--- a/lecture/pattern/visitor.md
+++ b/lecture/pattern/visitor.md
@@ -140,7 +140,7 @@ challenges: |
 ---
 
 
-## Motivation: Parsen von "5*4+3"
+# Motivation: Parsen von "5*4+3"
 
 ::::::::: {.columns}
 :::::: {.column width="50%"}
@@ -171,7 +171,7 @@ Beim Parsen von "5*4+3" würde dabei der folgende Parsetree entstehen:
 :::::::::
 
 
-## Strukturen für den Parsetree
+# Strukturen für den Parsetree
 
 ![](images/parsetree_classes_uml.png){width="70%"}
 
@@ -222,7 +222,7 @@ public class DemoExpr {
 :::
 
 
-## Ergänzung I: Ausrechnen des Ausdrucks
+# Ergänzung I: Ausrechnen des Ausdrucks
 
 ::: notes
 Es wäre nun schön, wenn man mit dem Parsetree etwas anfangen könnte. Vielleicht
@@ -283,7 +283,7 @@ public class DemoExpr {
 :::
 
 
-## Ergänzung II: Pretty-Print des Ausdrucks
+# Ergänzung II: Pretty-Print des Ausdrucks
 
 ::: notes
 Nachdem das Ausrechnen so gut geklappt hat, will der Chef nun noch flink eine Funktion,
@@ -305,7 +305,7 @@ immer _alle_ Expression-Klassen anpassen!
 **Das geht besser.**
 
 
-## Visitor-Pattern (Besucher-Entwurfsmuster)
+# Visitor-Pattern (Besucher-Entwurfsmuster)
 
 ![](images/visitor.png){web_width="80%"}
 
@@ -417,7 +417,7 @@ public class DemoExpr {
 }
 ```
 
-### Implementierungsdetail
+## Implementierungsdetail
 
 In den beiden Klasse `AddExpr` und `MulExpr` müssen auch die beiden Kindknoten besucht
 werden, d.h. hier muss der Baum weiter traversiert werden.
@@ -434,12 +434,12 @@ Post-Order, ...) und diese elegant in den Visitor verlagern kann.
 
 [Beispiel Traversierung extern (im Visitor): visitor.visit.extrav.DemoExpr]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/pattern/src/visitor/visit/extrav/DemoExpr.java"}
 
-### (Double-) Dispatch
+## (Double-) Dispatch
 
 Zur Laufzeit wird in `accept()` der Typ des Visitors aufgelöst und dann in `visit()` der
 Typ der zu besuchenden Klasse. Dies nennt man auch "Double-Dispatch".
 
-### Hinweis I
+## Hinweis I
 
 Man könnte versucht sein, die `accept()`-Methode aus den Knotenklassen in die gemeinsame
 Basisklasse zu verlagern: Statt
@@ -465,7 +465,7 @@ public abstract class Expr {
 Dies wäre tatsächlich schön, weil man so Code-Duplizierung vermeiden könnte. Aber es
 funktioniert in Java leider nicht. (Warum?)
 
-### Hinweis II
+## Hinweis II
 
 Während die `accept()`-Methode nicht in die Basisklasse der besuchten Typen (im Bild oben
 die Klasse `Elem` bzw. im Beispiel oben die Klasse `Expr`) verlagert werden kann, kann man
@@ -474,14 +474,14 @@ implementieren.
 :::
 
 
-## Ausrechnen des Ausdrucks mit einem Visitor
+# Ausrechnen des Ausdrucks mit einem Visitor
 
 ![](images/parsetree_visitor_uml.png)
 
 [Demo: visitor.visit.extrav.DemoExpr]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/pattern/src/visitor/visit/extrav/DemoExpr.java"}
 
 
-## Wrap-Up
+# Wrap-Up
 
 **Visitor-Pattern**: Auslagern der Traversierung in eigene Klassenstruktur
 

--- a/lecture/quality/codingrules.md
+++ b/lecture/quality/codingrules.md
@@ -73,7 +73,7 @@ attachments:
 ---
 
 
-## Coding Conventions: Richtlinien für einheitliches Aussehen von Code
+# Coding Conventions: Richtlinien für einheitliches Aussehen von Code
 
 => Ziel: Andere Programmierer sollen Code schnell lesen können
 
@@ -94,7 +94,7 @@ Beispiele: [Sun Code Conventions](https://www.oracle.com/technetwork/java/codeco
 [AOSP Java Code Style for Contributors](https://source.android.com/docs/setup/contribute/code-style)
 
 
-## Beispiel nach Google Java Style/AOSP formatiert
+# Beispiel nach Google Java Style/AOSP formatiert
 
 ```java
 package wuppie.deeplearning.strategy;
@@ -153,7 +153,7 @@ auf [Google Java Style](https://google.github.io/styleguide/javaguide.html) und 
 :::
 
 
-## Formatieren Sie Ihren Code (mit der IDE)
+# Formatieren Sie Ihren Code (mit der IDE)
 
 ::: notes
 Sie können den Code manuell formatieren, oder aber (sinnvollerweise) über Tools
@@ -187,7 +187,7 @@ formatieren lassen. Hier einige Möglichkeiten:
 
 
 ::::::::: notes
-### Einstellungen der IDE's
+## Einstellungen der IDE's
 
 *   Eclipse:
     *   `Project > Properties > Java Code Style > Formatter`: Coding-Style einstellen/einrichten
@@ -210,7 +210,7 @@ Analog sollte man bei der Verwendung von Checkstyle auch in der IDE im Formatter
 Checkstyle-Regeln (s.u.) passend einstellen, sonst bekommt man durch Checkstyle Warnungen angezeigt,
 die man durch ein automatisches Formatieren _nicht_ beheben kann.
 
-### Google Java Style und google-java-format
+## Google Java Style und google-java-format
 
 Wer direkt den [Google Java Style](https://google.github.io/styleguide/javaguide.html) nutzt,
 kann auch den dazu passenden Formatter von Google einsetzen:
@@ -219,7 +219,7 @@ Diesen kann man entweder als Plugin für IntelliJ/Eclipse einsetzen oder als Sta
 (Kommandozeile oder Build-Skripte) aufrufen. Wenn man sich noch einen entsprechenden
 Git-Hook definiert, wird vor jedem Commit der Code entsprechend den Richtlinien formatiert :)
 
-### Spotless und google-java-format in Gradle
+## Spotless und google-java-format in Gradle
 
 _Hinweis_: Bei Spotless in Gradle müssen je nach den Versionen von Spotless/google-java-format
 bzw. des JDK noch Optionen in der Datei `gradle.properties` eingestellt werden (siehe
@@ -241,14 +241,14 @@ docker run --rm -it  -v "$PWD":/data -w /data  --entrypoint "bash"  gradle
 [Demo: Konfiguration Formatter (IDE), Spotless/Gradle]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/quality/src/formatter/"}
 
 
-## Metriken: Kennzahlen für verschiedene Aspekte zum Code
+# Metriken: Kennzahlen für verschiedene Aspekte zum Code
 
 ::::::::: notes
 Metriken messen verschiedene Aspekte zum Code und liefern eine Zahl zurück. Mit Metriken kann
 man beispielsweise die Einhaltung der Coding Rules (Formate, ...) prüfen, aber auch die Einhaltung
 verschiedener Regeln des objektorientierten Programmierens.
 
-### Beispiele für wichtige Metriken (jeweils Max-Werte für PM)
+## Beispiele für wichtige Metriken (jeweils Max-Werte für PM)
 
 Die folgenden Metriken und deren Maximal-Werte sind gute Erfahrungswerte aus der Praxis und helfen,
 den Code Smell "Langer Code"  (vgl. ["Code Smells"](smells.md)) zu
@@ -280,7 +280,7 @@ Dennoch sind das keine absoluten Werte an sich. Ein Übertreten der Grenzen ist 
 **Hinweis** darauf, dass **höchstwahrscheinlich** etwas nicht stimmt, muss aber im
 konkreten Fall hinterfragt und diskutiert und begründet werden!
 
-### Metriken im Beispiel von oben
+## Metriken im Beispiel von oben
 
 ```java
     private static String lastName;
@@ -311,7 +311,7 @@ d.h. `String` würde im obigen Beispiel _nicht_ bei DAC mitgezählt/angezeigt.
 => Verweis auf LV Softwareengineering
 
 
-## Tool-Support: Checkstyle
+# Tool-Support: Checkstyle
 
 ::::::::: notes
 Metriken und die Einhaltung von Coding-Conventions werden sinnvollerweise nicht manuell,
@@ -359,7 +359,7 @@ docker run --rm -it  -v "$PWD":/data -w /data  --entrypoint "bash"  gradle
 [Demo: IntelliJ, Checkstyle/Gradle]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/tree/master/lecture/quality/src/checkstyle/"}
 
 
-## Checkstyle: Konfiguration
+# Checkstyle: Konfiguration
 
 ::::::::: notes
 Die auszuführenden Checks lassen sich über eine [XML-Datei](https://checkstyle.org/config.html)
@@ -413,7 +413,7 @@ Alternativen/Ergänzungen: beispielsweise [MetricsReloaded](https://github.com/B
 [Demo: Konfiguration mit Eclipse-CS, Hinweis auf Formatter]{.ex href="https://youtu.be/0ny6e6CNTF8"}
 
 
-## SpotBugs: Finde Anti-Pattern und potentielle Bugs (Linter)
+# SpotBugs: Finde Anti-Pattern und potentielle Bugs (Linter)
 
 *   [**SpotBugs**](https://github.com/spotbugs/spotbugs) sucht nach über 400 potentiellen Bugs im Code
     *   Anti-Pattern (schlechte Praxis, "dodgy" Code)
@@ -448,7 +448,7 @@ docker run --rm -it  -v "$PWD":/data -w /data  --entrypoint "bash"  gradle
 [Demo: SpotBugs/Gradle]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/tree/master/lecture/quality/src/spotbugs/"}
 
 
-## Konfiguration für das PM-Praktikum (Format, Metriken, Checkstyle, SpotBugs)
+# Konfiguration für das PM-Praktikum (Format, Metriken, Checkstyle, SpotBugs)
 
 ::: notes
 Im PM-Praktikum beachten wir die obigen Coding Conventions und Metriken mit den dort definierten
@@ -456,7 +456,7 @@ Grenzwerten. Diese sind bereits in der bereit gestellten Minimal-Konfiguration f
 (s.u.) konfiguriert.
 :::
 
-### Formatierung
+## Formatierung
 
 *   Google Java Style/AOSP: **Spotless**
 
@@ -473,7 +473,7 @@ Formatter Ihrer IDE entsprechend ein.
 
 \bigskip
 
-### Checkstyle
+## Checkstyle
 
 *   Minimal-Konfiguration für **Checkstyle** (Coding Conventions, Metriken)
 
@@ -557,7 +557,7 @@ Google Java Style hinaus.
 
 \bigskip
 
-### Linter: SpotBugs
+## Linter: SpotBugs
 
 *   Vermeiden von Anti-Pattern mit **SpotBugs**
 
@@ -567,7 +567,7 @@ Fehler beinhalten, die SpotBugs melden würde.
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Code entsteht nicht zum Selbstzweck => Regeln nötig!
     *   Coding Conventions

--- a/lecture/quality/javadoc.md
+++ b/lecture/quality/javadoc.md
@@ -53,7 +53,7 @@ challenges: |
 ---
 
 
-## Dokumentation mit Javadoc
+# Dokumentation mit Javadoc
 
 ```java
 /**
@@ -83,7 +83,7 @@ Aufruf gern für Sie tätigt).
 :::
 
 
-## Standard-Aufbau
+# Standard-Aufbau
 
 ```java
 /**
@@ -134,7 +134,7 @@ public int setDate(int date) {
 :::
 
 
-## Veraltete Elemente
+# Veraltete Elemente
 
 ```java
 /**
@@ -156,7 +156,7 @@ beibehalten und danach das veraltete Element aus der API entfernt.
 :::
 
 
-## Autoren, Versionen, ...
+# Autoren, Versionen, ...
 
 ```java
 /**
@@ -175,7 +175,7 @@ Diese Annotationen finden Sie vor allem in Kommentaren zu Packages oder Klassen.
 :::
 
 
-## Was muss kommentiert werden?
+# Was muss kommentiert werden?
 
 *   Alle `public` Klassen
 *   Alle `public` und `protected` Elemente der Klassen
@@ -190,7 +190,7 @@ Diese Annotationen finden Sie vor allem in Kommentaren zu Packages oder Klassen.
 Alle anderen Elemente bei Bedarf mit _normalen_ Kommentaren versehen.
 
 ::: notes
-### Beispiel aus dem JDK: ArrayList
+## Beispiel aus dem JDK: ArrayList
 
 Schauen Sie sich gern mal Klassen aus der Java-API an, beispielsweise eine `java.util.ArrayList`:
 *   Generierte Dokumentation:
@@ -198,14 +198,14 @@ Schauen Sie sich gern mal Klassen aus der Java-API an, beispielsweise eine `java
     bzw. [direkt](https://docs.oracle.com/javase/8/docs/api/java/util/ArrayList.html)
 *   Quellcode: [ArrayList.java](https://hg.openjdk.java.net/jdk8/jdk8/jdk/file/tip/src/share/classes/java/util/ArrayList.java)
 
-### Best Practices: Was beschreibe ich eigentlich?
+## Best Practices: Was beschreibe ich eigentlich?
 
 Unter [Documentation Best Practices](https://github.com/google/styleguide/blob/gh-pages/docguide/best_practices.md#documentation-is-the-story-of-your-code)
 finden Sie eine sehr gute Beschreibung, was das Ziel der Dokumentation sein sollte. Versuchen Sie, dieses zu erreichen!
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Javadoc-Kommentare sind normale Block-Kommentare beginnend mit `/**`
 *   Generierung der HTML-Dokumentation mit `javadoc *.java`

--- a/lecture/quality/junit-basics.md
+++ b/lecture/quality/junit-basics.md
@@ -129,7 +129,7 @@ challenges: |
 ---
 
 
-## JUnit: Ergebnis prüfen
+# JUnit: Ergebnis prüfen
 
 Klasse **`org.junit.Assert`** enthält diverse **statische** Methoden zum Prüfen:
 
@@ -150,7 +150,7 @@ void fail();
 ```
 
 
-## To "assert" or to "assume"?
+# To "assert" or to "assume"?
 
 *   Mit `assert*` werden Testergebnisse geprüft
     *   Test wird ausgeführt
@@ -165,7 +165,7 @@ void fail();
 [Beispiel: junit4.TestAssume]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/quality/src/junit4/TestAssume.java"}
 
 
-## Setup und Teardown: Testübergreifende Konfiguration
+# Setup und Teardown: Testübergreifende Konfiguration
 
 ```java
 private Studi x;
@@ -208,7 +208,7 @@ In JUnit 5 wurden die Namen dieser Annotationen leicht geändert:
 
 
 ::: notes
-## Beispiel für den Einsatz von `@Before`
+# Beispiel für den Einsatz von `@Before`
 
 Annahme: **alle/viele** Testmethoden brauchen **neues** Objekt `x` vom Typ `Studi`
 
@@ -236,7 +236,7 @@ public void testGetName() {
 
 
 ::: notes
-## Ignorieren von Tests
+# Ignorieren von Tests
 
 *   Hinzufügen der Annotation `@Ignore`
 *   Alternativ mit Kommentar: `@Ignore("Erst im nächsten Release")`
@@ -269,7 +269,7 @@ mit dem Grund für das Ignorieren des Tests hinterlegen.
 :::
 
 
-## Vermeidung von Endlosschleifen: Timeout
+# Vermeidung von Endlosschleifen: Timeout
 
 ::: notes
 *   Testfälle werden nacheinander ausgeführt
@@ -316,7 +316,7 @@ void testTestDauerlaeufer() {
 :::
 
 
-## Test von Exceptions: Expected
+# Test von Exceptions: Expected
 
 ::: notes
 Traditionelles Testen von Exceptions mit `try` und `catch`:
@@ -370,7 +370,7 @@ public void testExceptAnnot() {
 :::
 
 
-## Parametrisierte Tests
+# Parametrisierte Tests
 
 ::: notes
 Manchmal möchte man den selben Testfall mehrfach mit anderen Werten (Parametern)
@@ -410,7 +410,7 @@ sind (Code-Duplizierung).
 
 
 ::: notes
-### Parametrisierte Tests mit JUnit 4
+## Parametrisierte Tests mit JUnit 4
 
 JUnit 4 bietet für dieses Problem sogenannte "parametrisierte Tests" an. Dafür
 muss eine Testklasse in JUnit 4 folgende Bedingungen erfüllen:
@@ -438,10 +438,11 @@ Letztlich wird damit das Kreuzprodukt aus Testmethoden und Testdaten durchgefüh
 :::
 
 ::: slides
-## Parametrisierte Tests: Konstruktor (JUnit 4)
+# Parametrisierte Tests: Konstruktor (JUnit 4)
 :::
+
 ::: notes
-#### (A) Parametrisierte Tests: Konstruktor (JUnit 4)
+### (A) Parametrisierte Tests: Konstruktor (JUnit 4)
 :::
 
 ```java
@@ -466,10 +467,11 @@ public class SumTestConstructor {
 ```
 
 ::: slides
-## Parametrisierte Tests: Parameter (JUnit 4)
+# Parametrisierte Tests: Parameter (JUnit 4)
 :::
+
 ::: notes
-#### (B) Parametrisierte Tests: Parameter (JUnit 4)
+### (B) Parametrisierte Tests: Parameter (JUnit 4)
 :::
 
 ```java
@@ -496,7 +498,7 @@ public class SumTestParameters {
 
 
 ::: notes
-### Parametrisierte Tests mit JUnit 5
+## Parametrisierte Tests mit JUnit 5
 
 In JUnit 5 werden [parametrisierte Tests] mit der Annotation [`@ParameterizedTest`]
 gekennzeichnet (statt mit `@Test`).
@@ -547,7 +549,7 @@ public class SumTest {
 :::
 
 
-## Testsuiten: Tests gemeinsam ausführen (JUnit 4)
+# Testsuiten: Tests gemeinsam ausführen (JUnit 4)
 
 ::: notes
 Eclipse: `New > Other > Java > JUnit > JUnit Test Suite`
@@ -571,7 +573,7 @@ public class MyTestSuite {
 ```
 
 ::: notes
-## Testsuiten mit JUnit 5
+# Testsuiten mit JUnit 5
 
 In JUnit 5 gibt es zwei Möglichkeiten, Testsuiten zu erstellen:
 
@@ -600,7 +602,7 @@ auf der "JUnit 5"-Plattform ausgeführt, sondern mit der JUnit 4-Infrastuktur!
 
 
 ::: notes
-## Best Practices
+# Best Practices
 
 1.  Ein Testfall behandelt exakt eine Idee/ein Szenario. Das bedeutet auch, dass man in der
     Regel nur ein bis wenige `assert*` pro Testmethode benutzt.
@@ -664,7 +666,7 @@ Diese Erfahrungen werden ausführlich in [@SWEGoogle, pp. 231-256] diskutiert.
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 JUnit als Framework für (Unit-) Tests; hier JUnit 4 (mit Ausblick auf JUnit 5)
 

--- a/lecture/quality/mockito.md
+++ b/lecture/quality/mockito.md
@@ -170,10 +170,10 @@ challenges: |
 ---
 
 
-## Motivation: Entwicklung einer Studi-/Prüfungsverwaltung
+# Motivation: Entwicklung einer Studi-/Prüfungsverwaltung
 
 ::: notes
-### Szenario
+## Szenario
 
 Zwei Teams entwickeln eine neue Studi-/Prüfungsverwaltung für die Hochschule. Ein Team modelliert dabei
 die Studierenden, ein anderes Team modelliert die Prüfungsverwaltung LSF.
@@ -220,7 +220,7 @@ Wie kann Team A seinen Code testen?
 :::
 
 ::::::::: notes
-### Motivation Mocking und Mockito
+## Motivation Mocking und Mockito
 
 [Mockito](https://github.com/mockito/mockito) ist ein Mocking-Framework für JUnit. Es
 simuliert das Verhalten eines realen Objektes oder einer realen Methode.
@@ -250,7 +250,7 @@ externen Abhängigkeiten zu lösen, indem es sogenannte Mocks, Stubs oder Spies
 anbietet, mit denen sich das Verhalten der realen Objekte simulieren/überwachen
 und testen lässt.
 
-### Aber was genau ist denn jetzt eigentlich Mocking?
+## Aber was genau ist denn jetzt eigentlich Mocking?
 
 Ein Mock-Objekt ("etwas vortäuschen") ist im Software-Test ein Objekt, das als Platzhalter
 (Attrappe) für das echte Objekt verwendet wird.
@@ -277,7 +277,7 @@ Dabei ist es von Vorteil die drei Grundbegriffe "Mock", "Stub" oder "Spy", auf d
 in der Vorlesung noch häufiger treffen werden, voneinander abgrenzen und
 unterscheiden zu können.
 
-### Dabei bezeichnet ein
+## Dabei bezeichnet ein
 
 *   **Stub**: Ein Stub ist ein Objekt, dessen Methoden nur mit einer minimalen Logik
     für den Test implementiert wurden. Häufig werden dabei einfach feste (konstante)
@@ -288,7 +288,7 @@ unterscheiden zu können.
 *   **Spy**: Ein Spy ist ein Objekt, welches Aufrufe und übergebene Werte protokolliert und
     abfragbar macht. Es ist also eine Art Wrapper um einen Stub oder einen Mock.
 
-### Mockito Setup
+## Mockito Setup
 
 *   Gradle: `build.gradle`
 
@@ -317,7 +317,7 @@ unterscheiden zu können.
 :::::::::
 
 
-## Manuell Stubs implementieren
+# Manuell Stubs implementieren
 
 ::: notes
 Team A könnte manuell das LSF rudimentär implementieren (nur für die Tests, einfach mit
@@ -356,7 +356,7 @@ Wenn man im Test andere Antworten braucht, müsste man einen weiteren Stub anleg
 [Demo hsbi.StudiStubTest]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/quality/src/mockito/src/test/java/hsbi/StudiStubTest.java"}
 
 
-## Mockito: Mocking von ganzen Klassen
+# Mockito: Mocking von ganzen Klassen
 
 ::: notes
 **Lösung**: Mocking der Klasse `LSF` mit Mockito für den Test von `Studi`: `mock()`.
@@ -407,7 +407,7 @@ Mit Hilfe der Argument-Matcher `anyString()` wird jedes String-Argument akzeptie
 [Demo hsbi.StudiMockTest]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/quality/src/mockito/src/test/java/hsbi/StudiMockTest.java"}
 
 
-## Mockito: Spy = Wrapper um ein Objekt
+# Mockito: Spy = Wrapper um ein Objekt
 
 ::: notes
 Team B hat das `LSF` nun implementiert und Team A kann es endlich für die Tests benutzen. Aber
@@ -460,7 +460,7 @@ Auch hier können Argument-Matcher wie `anyString()` eingesetzt werden.
 [Demo hsbi.StudiSpyTest]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/quality/src/mockito/src/test/java/hsbi/StudiSpyTest.java"}
 
 
-## Wurde eine Methode aufgerufen?
+# Wurde eine Methode aufgerufen?
 
 ```java
 public class VerifyTest {
@@ -521,7 +521,7 @@ Reihenfolge bringen und so überprüfen.
 [Demo hsbi.VerifyTest]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/quality/src/mockito/src/test/java/hsbi/VerifyTest.java"}
 
 
-## Fangen von Argumenten
+# Fangen von Argumenten
 
 ```java
 public class MatcherTest {
@@ -569,7 +569,7 @@ von [Mockito](https://javadoc.io/doc/org.mockito/mockito-core/) an.
 [Demo hsbi.MatcherTest]{.ex href="https://github.com/Programmiermethoden-CampusMinden/Prog2-Lecture/blob/master/lecture/quality/src/mockito/src/test/java/hsbi/MatcherTest.java"}
 
 
-## Ausblick: PowerMock
+# Ausblick: PowerMock
 
 Mockito sehr mächtig, aber unterstützt (u.a.) keine
 
@@ -586,7 +586,7 @@ Mockito sehr mächtig, aber unterstützt (u.a.) keine
 
 
 ::::::::: notes
-## Ausführlicheres Beispiel: WuppiWarenlager
+# Ausführlicheres Beispiel: WuppiWarenlager
 
 **Credits**: Der Dank für die Erstellung des nachfolgenden Beispiels und Textes geht an
 [\@jedi101](https://github.com/jedi101).
@@ -612,7 +612,7 @@ händisch in den Stub des Warenlagers einpflegen.
 
 Das will eigentlich niemand...
 
-### Einsatz von Mockito
+## Einsatz von Mockito
 
 Aber es gibt da einen Ausweg. Wenn es komplexer wird, verwenden wir Mocks.
 
@@ -651,7 +651,7 @@ bestellteWuppis = wuppiStore.bestelleAlleWuppis(lager);
 assertEquals(2,bestellteWuppis.size());
 ```
 
-### Mockito Spies
+## Mockito Spies
 
 Manchmal möchten wir allerdings nicht immer gleich ein ganzes Objekt mocken,
 aber dennoch Einfluss auf die aufgerufenen Methoden eines Objekts haben, um
@@ -692,7 +692,7 @@ Die normalen Testmöglichkeiten von JUnit runden unseren Test zudem ab.
 assertEquals(1,wuppiWarenlager.lager.size());
 ```
 
-## Mockito und Annotationen
+# Mockito und Annotationen
 
 In Mockito können Sie wie oben gezeigt mit `mock()` und `spy()` neue
 Mocks bzw. Spies erzeugen und mit `verify()` die Interaktion überprüfen
@@ -759,7 +759,7 @@ ein kleiner Überblick über die wichtigsten in Mockito verwendeten Annotation:
     `@BeforeEach`).
 
 
-### Prüfen der Interaktion mit  _verify()_
+## Prüfen der Interaktion mit  _verify()_
 
 Mit Hilfe der umfangreichen `verify()`-Methoden, die uns Mockito mitliefert, können
 wir unseren Code unter anderem auf unerwünschte Seiteneffekte testen. So ist es mit
@@ -814,7 +814,7 @@ public void testVerify_InteraktionenMitHilfeDesArgumentCaptor() {
 :::::::::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Gründliches Testen ist ebenso viel Aufwand wie Coden!
 

--- a/lecture/quality/refactoring.md
+++ b/lecture/quality/refactoring.md
@@ -58,7 +58,7 @@ challenges: |
 ---
 
 
-## Was ist Refactoring?
+# Was ist Refactoring?
 
 > Refactoring ist, wenn einem auffällt, daß der Funktionsname `foobar`
 > ziemlich bescheuert ist, und man die Funktion in `sinus` umbenennt.
@@ -87,7 +87,7 @@ challenges: |
 :::
 
 
-## Anzeichen, dass Refactoring jetzt eine gute Idee wäre
+# Anzeichen, dass Refactoring jetzt eine gute Idee wäre
 
 *   Code "stinkt" (zeigt/enthält _Code Smells_)
 
@@ -145,7 +145,7 @@ sinnvoll ist.
 :::
 
 
-## Bevor Sie loslegen ...
+# Bevor Sie loslegen ...
 
 1.  **Unit Tests** schreiben
     *   Normale und ungültige Eingaben
@@ -162,10 +162,10 @@ sinnvoll ist.
 3.  Haben Sie die fragliche Codestelle auch wirklich verstanden?!
 
 
-## Vorgehen beim Refactoring
+# Vorgehen beim Refactoring
 
 ::: notes
-### Überblick über die Methoden des Refactorings
+## Überblick über die Methoden des Refactorings
 
 Die Refactoring-Methoden sind nicht einheitlich definiert, es existiert ein großer
 und uneinheitlicher "Katalog" an möglichen Schritten. Teilweise benennt jede IDE
@@ -179,7 +179,7 @@ Zu den am häufigsten genutzten Methoden zählen
 *   Move Method
 *   Pull Up, Push Down (Field, Method)
 
-### Best Practice
+## Best Practice
 
 Eine Best Practice (oder nennen Sie es einfach eine wichtige Erfahrung) ist,
 beim Refactoring langsam und gründlich vorzugehen. Sie ändern die Struktur
@@ -200,22 +200,22 @@ grün sein (oder Sie haben einen Fehler gemacht).
 *   Versionskontrolle nutzen: **Jeden** Schritt **einzeln** committen
 
 
-## Refactoring-Methode: Rename Method/Class/Field
+# Refactoring-Methode: Rename Method/Class/Field
 
 ::: notes
-### Motivation
+## Motivation
 
 Name einer Methode/Klasse/Attributs erklärt nicht ihren Zweck.
 
-### Durchführung
+## Durchführung
 
 Name selektieren, "`Refactor > Rename`"
 
-### Anschließend ggf. prüfen
+## Anschließend ggf. prüfen
 
 Aufrufer? Superklassen?
 
-### Beispiel
+## Beispiel
 :::
 
 **Vorher**
@@ -232,22 +232,22 @@ public String getTelefonNummer() {}
 
 
 
-## Refactoring-Methode: Encapsulate Field
+# Refactoring-Methode: Encapsulate Field
 
 ::: notes
-### Motivation
+## Motivation
 
 Sichtbarkeit von Attributen reduzieren.
 
-### Durchführung
+## Durchführung
 
 Attribut selektieren, "`Refactor > Encapsulate Field`"
 
-### Anschließend ggf. prüfen
+## Anschließend ggf. prüfen
 
 Superklassen? Referenzen? (Neue) JUnit-Tests?
 
-### Beispiel
+## Beispiel
 :::
 
 **Vorher**
@@ -274,10 +274,10 @@ public void printDetails() {
 ```
 
 
-## Refactoring-Methode: Extract Method/Class
+# Refactoring-Methode: Extract Method/Class
 
 ::: notes
-### Motivation
+## Motivation
 
 *   Codefragment stellt eigenständige Methode dar
 *   "Überschriften-Code"
@@ -285,11 +285,11 @@ public void printDetails() {
 *   Code ist zu "groß"
 *   Klasse oder Methode erfüllt unterschiedliche Aufgaben
 
-### Durchführung
+## Durchführung
 
 Codefragment selektieren, "`Refactor > Extract Method`" bzw. "`Refactor > Extract Class`"
 
-### Anschließend ggf. prüfen
+## Anschließend ggf. prüfen
 
 *   Aufruf der neuen Methode? Nutzung der neuen Klasse?
 *   Neue JUnit-Tests nötig? Veränderung bestehender Tests nötig?
@@ -298,7 +298,7 @@ Codefragment selektieren, "`Refactor > Extract Method`" bzw. "`Refactor > Extrac
     *   Veränderung lokaler Variablen: Rückgabewert in neuer Methode
         und Zuweisung bei Aufruf; evtl. neue Typen nötig!
 
-### Beispiel
+## Beispiel
 :::
 
 **Vorher**
@@ -326,20 +326,20 @@ private void printDetails() {
 ```
 
 
-## Refactoring-Methode: Move Method
+# Refactoring-Methode: Move Method
 
 ::: notes
-### Motivation
+## Motivation
 
 Methode nutzt (oder wird genutzt von) mehr Eigenschaften einer
 fremden Klasse als der eigenen Klasse.
 
-### Durchführung
+## Durchführung
 
 Methode selektieren, "`Refactor > Move`"
 (ggf. "Keep original method as delegate to moved method" aktivieren)
 
-### Anschließend ggf. prüfen
+## Anschließend ggf. prüfen
 
 *   Aufruf der neuen Methode (Delegation)?
 *   Neue JUnit-Tests nötig? Veränderung bestehender Tests nötig?
@@ -347,7 +347,7 @@ Methode selektieren, "`Refactor > Move`"
 *   Veränderung lokaler Variablen: Rückgabewert in neuer Methode
     und Zuweisung bei Aufruf; evtl. neue Typen nötig!
 
-### Beispiel
+## Beispiel
 :::
 
 **Vorher**
@@ -371,7 +371,7 @@ public class Studi extends Person {
 ```
 
 ::: slides
-## Refactoring-Methode: Move Method (cnt.)
+# Refactoring-Methode: Move Method (cnt.)
 :::
 
 **Nachher**
@@ -397,24 +397,24 @@ public class Studi extends Person {
 ```
 
 
-## Refactoring-Methode: Pull Up, Push Down (Field, Method)
+# Refactoring-Methode: Pull Up, Push Down (Field, Method)
 
 ::: notes
-### Motivation
+## Motivation
 
 *   Attribut/Methode nur für die Oberklasse relevant: **Pull Up**
 *   Subklassen haben identische Attribute/Methoden: **Pull Up**
 *   Attribut/Methode nur für eine Subklasse relevant: **Push Down**
 
-### Durchführung
+## Durchführung
 
 Name selektieren, "`Refactor > Pull Up`" oder "`Refactor > Push Down`"
 
-### Anschließend ggf. prüfen
+## Anschließend ggf. prüfen
 
 Referenzen/Aufrufer? JUnit-Tests?
 
-### Beispiel
+## Beispiel
 :::
 
 **Vorher**
@@ -439,7 +439,7 @@ public class Studi extends Person {
 ```
 
 
-## Wrap-Up
+# Wrap-Up
 
 Behebung von **Bad Smells** durch **Refactoring**
 

--- a/lecture/quality/smells.md
+++ b/lecture/quality/smells.md
@@ -36,7 +36,7 @@ attachments:
 ---
 
 
-## Code Smells: Ist das Code oder kann das weg?
+# Code Smells: Ist das Code oder kann das weg?
 
 ```java
 class checker {
@@ -88,7 +88,7 @@ Schauen Sie mal in die unten angegebene Literatur :-)
 :::
 
 
-## Was ist guter ("sauberer") Code ("Clean Code")?
+# Was ist guter ("sauberer") Code ("Clean Code")?
 
 ::: notes
 Im Grunde bezeichnet "sauberer Code" ("Clean Code") die Abwesenheit von Smells. D.h. man
@@ -112,7 +112,7 @@ zu diesem Thema zu Wort kommen - eine sehr lesenswerte Lektüre!
 => Jemand kümmert sich um den Code; solides Handwerk
 
 
-## Warum ist guter ("sauberer") Code so wichtig?
+# Warum ist guter ("sauberer") Code so wichtig?
 
 > Any fool can write code that a computer can understand.
 > Good programmers write code that humans can understand.
@@ -131,7 +131,7 @@ Praxis später nicht gut gepflegt: Andere Entwickler haben (die berechtigte) Ang
 kaputt zu machen und arbeiten "um den Code herum". Nur leider wird das Konstrukt dann
 nur noch schwerer verständlich ...
 
-### Code Smells
+## Code Smells
 
 Verstöße gegen die Prinzipien von _Clean Code_ nennt man auch _Code Smells_: Der
 Code "stinkt" gewissermaßen. Dies bedeutet nicht unbedingt, dass der Code nicht
@@ -151,7 +151,7 @@ was im Laufe der Zeit die Chance für tatsächliche Probleme deutlich erhöht.
 :::
 
 ::::::::: notes
-### "Broken Windows" Phänomen
+## "Broken Windows" Phänomen
 
 Wenn ein Gebäude leer steht, wird es eine gewisse Zeit lang nur relativ langsam
 verfallen: Die Fenster werden nicht mehr geputzt, es sammelt sich Graffiti, Gras
@@ -173,7 +173,7 @@ schlecht ist ... Das wird mit der Zeit nicht besser ...
 ["Broken Windows" Phänomen]{.ex href="https://en.wikipedia.org/wiki/Broken_windows_theory"}
 
 ::::::::: notes
-### Maßeinheit für Code-Qualität ;-)
+## Maßeinheit für Code-Qualität ;-)
 
 Es gibt eine "praxisnahe" (und nicht ganz ernst gemeinte) Maßeinheit für Code-Qualität:
 Die "WTF/m" (_What the Fuck per minute_):
@@ -184,7 +184,7 @@ in Ordnung ...
 :::::::::
 
 
-## Code Smells: Nichtbeachtung von Coding Conventions
+# Code Smells: Nichtbeachtung von Coding Conventions
 
 *   Richtlinien für einheitliches Aussehen
     => Andere Programmierer sollen Code schnell lesen können
@@ -206,7 +206,7 @@ in Ordnung ...
 [[Hinweis: Genauere Betrachtung in "Coding Rules"]{.ex}]{.slides}
 
 
-## Code Smells: Schlechte Kommentare I
+# Code Smells: Schlechte Kommentare I
 
 *   Ratlose Kommentare
 
@@ -241,7 +241,7 @@ in Ordnung ...
     :::
 
 
-## Code Smells: Schlechte Kommentare II
+# Code Smells: Schlechte Kommentare II
 
 *   Veraltete Kommentare
 
@@ -281,7 +281,7 @@ in Ordnung ...
     :::
 
 
-## Code Smells: Schlechte Namen und fehlende Kapselung
+# Code Smells: Schlechte Namen und fehlende Kapselung
 
 ```java
 public class Studi extends Person {
@@ -320,7 +320,7 @@ gehören zur Schnittstelle und damit Teil des "Vertrags" mit den Nutzern!
     :::
 
 
-## Code Smells: Duplizierter Code
+# Code Smells: Duplizierter Code
 
 ```java
 public class Studi {
@@ -351,7 +351,7 @@ Kopierter/duplizierter Code ist problematisch:
 :::
 
 
-## Code Smells: Langer Code
+# Code Smells: Langer Code
 
 *   Lange Klassen
     *   Faustregel: 5 Bildschirmseiten sind viel
@@ -379,7 +379,7 @@ Kopierter/duplizierter Code ist problematisch:
 \bigskip
 
 ::::::::: notes
-### Lesbarkeit und Übersichtlichkeit leiden
+## Lesbarkeit und Übersichtlichkeit leiden
 
 *   Der Mensch kann sich nur begrenzt viele Dinge im Kurzzeitgedächtnis merken
 *   Klassen, die länger als 5 Bildschirmseiten sind, erfordern viel Hin- und
@@ -392,7 +392,7 @@ Kopierter/duplizierter Code ist problematisch:
 *   Große Dateien verleiten (auch mangels Übersichtlichkeit) dazu, neuen
     Code ebenfalls schluderig zu gliedern
 
-### Langer Code deutet auch auf eine Verletzung des Prinzips der Single Responsibility hin
+## Langer Code deutet auch auf eine Verletzung des Prinzips der Single Responsibility hin
 
 *   Klassen fassen evtl. nicht zusammengehörende Dinge zusammen
 
@@ -440,7 +440,7 @@ Kopierter/duplizierter Code ist problematisch:
 :::::::::
 
 
-## Code Smells: Feature Neid
+# Code Smells: Feature Neid
 
 ```java
 public class CreditsCalculator {
@@ -466,14 +466,14 @@ public class CreditsCalculator {
 
 
 ::: notes
-## Weiterführende Links
+# Weiterführende Links
 
 *   ["Foundations: Clean Code" (The Odin Project)](https://www.theodinproject.com/lessons/foundations-clean-code)
 *   ["Documentation Best Practices" (Google Styleguide)](https://github.com/google/styleguide/blob/gh-pages/docguide/best_practices.md)
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Code entsteht nicht zum Selbstzweck => Lesbarkeit ist wichtig
 

--- a/lecture/quality/tdd.md
+++ b/lecture/quality/tdd.md
@@ -41,10 +41,10 @@ fhmedia:
 ---
 
 
-## Design für Testbarkeit
+# Design für Testbarkeit
 
 ::: notes
-### Schlechtes Beispiel
+## Schlechtes Beispiel
 :::
 
 ```java
@@ -61,7 +61,7 @@ public void ausgabe(...) {
 \smallskip
 
 ::: notes
-### Etwas verbessertes Beispiel
+## Etwas verbessertes Beispiel
 :::
 
 ```java
@@ -76,7 +76,7 @@ public void ausgabe(...) {
 }
 ```
 
-## Anzeichen für schlecht testbares Design
+# Anzeichen für schlecht testbares Design
 
 *   Keine Rückgabewerte
 *   Direkte Ausgaben
@@ -87,7 +87,7 @@ public void ausgabe(...) {
 *   Seiteneffekte, z.B. Berechnung und direkte Veränderung von Zuständen **anderer** Objekte
 
 
-## Private Methoden sind nicht (direkt) testbar
+# Private Methoden sind nicht (direkt) testbar
 
 1.  Gar nicht testen????
 
@@ -131,7 +131,7 @@ public void ausgabe(...) {
     :::
 
 
-## Was ist ein guter Test?
+# Was ist ein guter Test?
 
 *   Läuft schnell. Läuft schnell. Läuft schnell!!!
 
@@ -172,12 +172,12 @@ public void ausgabe(...) {
     :::
 
 
-## TDD oder der "Red-Green-Refactor"-Zyklus
+# TDD oder der "Red-Green-Refactor"-Zyklus
 
 ![](images/tdd.png){width="60%" web_width="40%"}
 
 ::: notes
-### Test-Driven Development (_TDD_)
+## Test-Driven Development (_TDD_)
 
 1.  Schreibe Test => schlägt fehl: "Red"
     *   Überlegen Sie, wie das Stück Software, welches Sie erstellen wollen,
@@ -211,7 +211,7 @@ _Anmerkung_: Jeder Zyklus sollte sehr kurz sein!
 [Demo: Validierung von Passwörtern]{.ex href="https://youtu.be/4NAcu8I8fJk"}
 
 ::: notes
-### Vorteile bei konsequenter Anwendung von TDD
+## Vorteile bei konsequenter Anwendung von TDD
 
 *   Kein ungetesteter Code mehr:
     Es entstehen automatisch viele Unit-Tests und gibt keinen Grund, keine Tests zu schreiben
@@ -225,7 +225,7 @@ _Anmerkung_: Jeder Zyklus sollte sehr kurz sein!
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Testbarkeit muss mitgedacht werden: SW-Design
 *   Private Methoden auch testen ("Sicherheitsnetz")

--- a/lecture/quality/testcases.md
+++ b/lecture/quality/testcases.md
@@ -200,7 +200,7 @@ challenges: |
 ---
 
 
-## Hands-On (10 Minuten): Wieviel und was muss man testen?
+# Hands-On (10 Minuten): Wieviel und was muss man testen?
 
 ```java
 public class Studi {
@@ -219,7 +219,7 @@ public class Studi {
 ```
 
 ::::::::: notes
-### _JEDE_ Methode mindestens testen mit/auf:
+## _JEDE_ Methode mindestens testen mit/auf:
 
 *   Positive Tests: Gutfall (Normalfall) => "gültige ÄK/GW"
 *   Negativ-Tests (Fehlbedienung, ungültige Werte) => "ungültige ÄK/GW"
@@ -231,7 +231,7 @@ public class Studi {
 => Wichtige Pfade im Code abgedeckt (White-Box)?
 
 
-### Praxis
+## Praxis
 
 *   Je kritischer eine Klasse/Methode/Artefakt ist, um so intensiver testen!
 *   Suche nach Kompromissen: Testkosten vs. Kosten von Folgefehlern;
@@ -242,7 +242,7 @@ Grenzwertanalyse (siehe nächste Folien). Mehr dann später im Wahlfach "Softwar
 :::::::::
 
 
-## Äquivalenzklassenbildung
+# Äquivalenzklassenbildung
 
 ::: notes
 Beispiel: Zu testende Methode mit Eingabewert _x_, der zw. 10 und 100 liegen soll
@@ -264,7 +264,7 @@ Beispiel: Zu testende Methode mit Eingabewert _x_, der zw. 10 und 100 liegen sol
 
 
 ::::::::: notes
-### Bemerkungen
+## Bemerkungen
 
 Hintergrund: Da die Werte einer ÄK zu gleichartigem Verhalten führen, ist es
 egal, _welchen_ Wert man aus einer ÄK für den Test nimmt.
@@ -282,7 +282,7 @@ auch die Ausgabeseite zu berücksichtigen (ist aber u.U. nur schwierig zu
 realisieren).
 
 
-### Faustregeln bei der Bildung von ÄK
+## Faustregeln bei der Bildung von ÄK
 
 *   Falls eine Beschränkung einen Wertebereich spezifiziert:
     Aufteilung in eine gültige und zwei ungültige ÄK
@@ -331,7 +331,7 @@ der laufenden Nummer $n$.
 :::::::::
 
 
-## ÄK: Erstellung der Testfälle
+# ÄK: Erstellung der Testfälle
 
 *   Jede ÄK durch _mindestens_ **einen TF** abdecken
 
@@ -359,9 +359,9 @@ miteinander in einem TF kombiniert werden! Bei gleichzeitiger Behandlung verschi
 :::
 
 
-## ÄK: Beispiel: Eingabewert _x_ soll zw. 10 und 100 liegen
+# ÄK: Beispiel: Eingabewert _x_ soll zw. 10 und 100 liegen
 
-### Äquivalenzklassen
+## Äquivalenzklassen
 
 | Eingabe | gültige ÄK        | ungültige ÄK    |
 |:--------|:------------------|:----------------|
@@ -371,7 +371,7 @@ miteinander in einem TF kombiniert werden! Bei gleichzeitiger Behandlung verschi
 \bigskip
 \pause
 
-### Tests
+## Tests
 
 | Testnummer          | 1    | 2         | 3         |
 |:--------------------|:-----|:----------|:----------|
@@ -380,7 +380,7 @@ miteinander in einem TF kombiniert werden! Bei gleichzeitiger Behandlung verschi
 | Erwartetes Ergebnis | OK   | Exception | Exception |
 
 
-## Grenzwertanalyse
+# Grenzwertanalyse
 
 ![](images/grenzwerte.png){width="60%" web_width="40%"}
 
@@ -410,9 +410,9 @@ nicht zu überlagern.**
 [[Beispiel: Eingabeparameter x zw. 10 und 100]{.ex}]{.slides}
 
 
-## GW: Beispiel: Eingabewert _x_ soll zw. 10 und 100 liegen
+# GW: Beispiel: Eingabewert _x_ soll zw. 10 und 100 liegen
 
-### Äquivalenzklassen
+## Äquivalenzklassen
 
 | Eingabe | gültige ÄK        | ungültige ÄK    |
 |:--------|:------------------|:----------------|
@@ -420,13 +420,13 @@ nicht zu überlagern.**
 |         |                   | uÄK3: $100 < x$ |
 
 
-### Grenzwertanalyse
+## Grenzwertanalyse
 
 [Zusätzliche Testdaten:]{.notes} 9 (uÄK2o) und 10 (gÄK1u) sowie 100 (gÄK1o) und 101 (uÄK3u)
 
 \pause
 
-### Tests
+## Tests
 
 | Testnummer          | 4     | 5     | 6         | 7         |
 |:--------------------|:------|:------|:----------|:----------|
@@ -449,7 +449,7 @@ GW-Analyse erhalten:
 
 
 ::: notes
-## Anmerkung: Analyse abhängiger Parameter
+# Anmerkung: Analyse abhängiger Parameter
 
 Wenn das Ergebnis von der Kombination der Eingabewerte abhängt, dann
 sollte man dies bei der Äquivalenzklassenbildung berücksichtigen: Die
@@ -471,7 +471,7 @@ Vergleiche @Kleuker2019, Abschnitt "4.4 Äquivalenzklassen und Objektorientierun
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
   *   Gründliches Testen ist ebenso viel Aufwand wie Coden
   *   Äquivalenzklassenbildung und Grenzwertanalyse

--- a/lecture/quality/testing-intro.md
+++ b/lecture/quality/testing-intro.md
@@ -112,7 +112,7 @@ challenges: |
 ---
 
 
-## Software-Fehler und ihre Folgen
+# Software-Fehler und ihre Folgen
 
 ![](images/swfehler.png){width="80%"}
 
@@ -120,7 +120,7 @@ challenges: |
 
 
 ::: notes
-## (Einige) Ursachen für Fehler
+# (Einige) Ursachen für Fehler
 
 *   Zeit- und Kostendruck
 *   Mangelhafte Anforderungsanalyse
@@ -132,7 +132,7 @@ challenges: |
 :::
 
 
-## Irgendjemand muss mit Deinen Bugs leben!
+# Irgendjemand muss mit Deinen Bugs leben!
 
 ::: notes
 Leider gibt es im Allgemeinen keinen Weg zu zeigen, dass eine Software korrekt ist.
@@ -167,7 +167,7 @@ das Testen automatisieren. Und hier kommt JUnit ins Spiel :)
 :::
 
 
-## Was wann testen? Wichtigste Teststufen
+# Was wann testen? Wichtigste Teststufen
 
 *   **Modultest**
     *   Testen einer Klasse und ihrer Methoden
@@ -190,7 +190,7 @@ das Testen automatisieren. Und hier kommt JUnit ins Spiel :)
 => Verweis auf Wahlfach "Softwarequalität"
 
 
-## JUnit: Test-Framework für Java
+# JUnit: Test-Framework für Java
 
 ::: notes
 **JUnit** --- Open Source Java Test-Framework zur Erstellung und
@@ -248,7 +248,7 @@ Version nicht mehr weiterentwickelt wird.
 :::
 
 
-## Anlegen und Organisation der Tests mit JUnit
+# Anlegen und Organisation der Tests mit JUnit
 
 :::::: columns
 ::: {.column width="50%"}
@@ -287,7 +287,7 @@ hintereinander (da sie im selben Paket sind und mit dem selben Namen anfangen)
 => besserer Überblick!
 
 
-## Anmerkung: Die (richtige) JUnit-Bibliothek muss im Classpath liegen!
+# Anmerkung: Die (richtige) JUnit-Bibliothek muss im Classpath liegen!
 
 Eclipse bringt für JUnit 4 und JUnit 5 die nötigen Jar-Dateien mit und fragt beim
 erstmaligen Anlegen einer neuen Testklasse, ob die für die ausgewählte Version
@@ -302,7 +302,7 @@ herunter und bindet sie in das Projekt ein.
 :::
 
 
-## JUnit 4+5: Definition von Tests
+# JUnit 4+5: Definition von Tests
 
 Annotation `@Test` vor Testmethode schreiben
 
@@ -329,7 +329,7 @@ aufweisen => vgl. Abschnitt "Dependency Injection for Constructors and Methods" 
 :::
 
 
-## JUnit 4: Ergebnis prüfen
+# JUnit 4: Ergebnis prüfen
 
 Klasse **`org.junit.Assert`** enthält diverse **statische** Methoden zum Prüfen:
 
@@ -354,7 +354,7 @@ Für JUnit 5 finden sich die Assert-Methoden im Package `org.junit.jupiter.api.A
 :::
 
 
-## Anmerkung zum statischen Import
+# Anmerkung zum statischen Import
 
 ::: notes
 Bei normalem Import der Klasse `Assert` muss man jeweils den voll qualifizierten Namen
@@ -390,7 +390,7 @@ import static packageName.className.*;
     ```
 
 
-## Mögliche Testausgänge bei JUnit
+# Mögliche Testausgänge bei JUnit
 
 :::::: columns
 ::: {.column width="55%"}
@@ -422,14 +422,14 @@ import static packageName.className.*;
 
 
 ::: notes
-## Anmerkungen zu Assert
+# Anmerkungen zu Assert
 
 *   Pro Testmethode möglichst nur **ein** Assert verwenden!
 *   Anderenfalls: Schlägt ein Assert fehl, wird der Rest nicht mehr überprüft ...
 :::
 
 
-## Wrap-Up
+# Wrap-Up
 
 *   Testen ist genauso wichtig wie Coden
 *   Richtiges Testen spart Geld, Zeit, ...

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ has_license: true
 ---
 
 
-## Kursbeschreibung
+# Kursbeschreibung
 
 Sie haben letztes Semester in **Prog1** die *wichtigsten* Elemente und Konzepte der
 Programmiersprache Java kennen gelernt.
@@ -46,7 +46,7 @@ und Logging auseinander setzen. Wenn uns dabei ein Entwurfsmuster "über den Weg
 wir die Gelegenheit nutzen und uns dieses genauer anschauen.
 
 
-## Überblick Modulinhalte
+# Überblick Modulinhalte
 
 1.  Fortgeschrittene Konzepte in Java ("Classic Java")
     - Reguläre Ausdrücke, Annotationen, Reflection
@@ -72,7 +72,7 @@ wir die Gelegenheit nutzen und uns dieses genauer anschauen.
 [^2]: nur als Wiederholung im Praktikum
 
 
-## Team
+# Team
 
 - [Carsten Gips] (Sprechstunde nach Vereinbarung)
 - [BC George] (Sprechstunde nach Vereinbarung)
@@ -82,7 +82,7 @@ wir die Gelegenheit nutzen und uns dieses genauer anschauen.
   [BC George]: https://www.hsbi.de/minden/ueber-uns/personenverzeichnis/birgit-christina-george
 
 
-## Kursformat
+# Kursformat
 
 ![](admin/images/fahrplan.png){width="80%"}
 
@@ -99,7 +99,7 @@ Sie *können* hierzu den Raum J101 bzw. J104 (vgl. Stundenplan) nutzen.
   [ILIAS]: https://www.hsbi.de/elearning/goto.php?target=crs_1486054&client_id=FH-Bielefeld
 
 
-## Fahrplan
+# Fahrplan
 
 Hier finden Sie einen abonnierbaren [Google Kalender] mit allen Terminen der Veranstaltung zum Einbinden in Ihre Kalender-App.
 
@@ -219,7 +219,7 @@ Bearbeitung der Quizzes jeweils **Sa, 00:00 Uhr (Vorwoche) bis Fr, 08:00 Uhr** [
 [Q09]: https://www.hsbi.de/elearning/goto.php?target=tst_1527345&client_id=FH-Bielefeld
 
 
-## Prüfungsform, Note und Credits
+# Prüfungsform, Note und Credits
 
 **Parcoursprüfung**, 5 ECTS (PO23)
 
@@ -228,7 +228,7 @@ dieser Lehrveranstaltung noch keine KI-gestützten Assistenten benutzen. Lösung
 ganz oder teilweise unter Zuhilfenahme von KI-Unterstützung erstellt wurden, werden wie nicht
 abgegeben behandelt.
 
-### Prüfung im ersten Zeitraum
+## Prüfung im ersten Zeitraum
 
 1.  **Quizzes**: mind. 5 der 9 Quizzes bestanden (ohne Note/Punkte)
     (Einzelbearbeitung, fristgerecht bis zur jeweiligen Vorlesung, je Quiz
@@ -264,7 +264,7 @@ verbessert sich die Gesamtnote um eine Teilnote.
 
 (Hinweise zur [Prüfungsvorbereitung] für Station I bis III)
 
-### Prüfung im zweiten Zeitraum
+## Prüfung im zweiten Zeitraum
 
 1.  **Station IV**: Schriftliche Prüfung (digitale Klausur) 90 Minuten in Minden im B40
 
@@ -273,9 +273,9 @@ verbessert sich die Gesamtnote um eine Teilnote.
 (Hinweise zur [Prüfungsvorbereitung] für Station IV)
 
 
-## Materialien
+# Materialien
 
-### Literatur
+## Literatur
 
 1.  ["**Java ist auch eine Insel**"]. Ullenboom, C., Rheinwerk-Verlag, 2021. ISBN
     [978-3-8362-8745-6].
@@ -291,7 +291,7 @@ verbessert sich die Gesamtnote um eine Teilnote.
   ["The Java Tutorials"]: https://docs.oracle.com/javase/tutorial/
   ["Learn Java"]: https://dev.java/learn/
 
-### Tools
+## Tools
 
 - JDK: **Java SE 21 (LTS)** ([Oracle] oder [Alternativen], bitte 64-bit Version nutzen)
 - IDE: [Eclipse IDE for Java Developers] oder [IntelliJ IDEA (Community Edition)] oder [Visual
@@ -307,9 +307,9 @@ verbessert sich die Gesamtnote um eine Teilnote.
   [Git]: https://git-scm.com/
 
 
-## Förderungen und Kooperationen
+# Förderungen und Kooperationen
 
-### Förderung durch DH.NRW (Digi Fellowships)
+## Förderung durch DH.NRW (Digi Fellowships)
 
 Die Überarbeitung dieser Lehrveranstaltung wurde vom Ministerium für Kultur und Wissenschaft
 (MKW) in NRW im Einvernehmen mit der Digitalen Hochschule NRW (DH.NRW) gefördert:
@@ -317,7 +317,7 @@ Die Überarbeitung dieser Lehrveranstaltung wurde vom Ministerium für Kultur un
 
 ["Fellowships für Innovationen in der digitalen Hochschulbildung"]: https://www.dh.nrw/kooperationen/Digi-Fellows-2
 
-### Kooperation mit dem DigikoS-Projekt
+## Kooperation mit dem DigikoS-Projekt
 
 Diese Vorlesung wurde vom Projekt ["Digitalbaukasten für kompetenzorientiertes Selbststudium"]
 (*DigikoS*) unterstützt. Ein vom DigikoS-Projekt ausgebildeter Digital Learning Scout hat
@@ -330,7 +330,7 @@ von der Stiftung Innovation in der Hochschullehre gefördert.
 
 ---
 
-## LICENSE
+# LICENSE
 
 [`<img src="https://licensebuttons.net/l/by-sa/4.0/88x31.png">`{=markdown}](https://creativecommons.org/licenses/by-sa/4.0/)
 


### PR DESCRIPTION
to simplify the tooling use H1 as the top outline level (and slide level) in all documents ...

see https://github.com/cagix/pandoc-lecture-zen/pull/27

closes #992